### PR TITLE
fix(Encryption-key): Ne pas générer la clé de cryptage si elle n'existe pas

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,10 +19,10 @@ DATE_DEPOT_FIN=
 STATUTS_DOSSIERS=
 GROUPES_INSTRUCTEURS=
 
-# Flask (optionnel)
+# Flask
 FLASK_SECRET_KEY=dev-key-change-in-production-2024
 # True = dev, False = prod
-FLASK_DEBUG=True
+FLASK_DEBUG=False
 
 DATABASE_URL=postgresql://user:password@host:port/db_name
 ENCRYPTION_KEY='encrypt-key'

--- a/docs/install.md
+++ b/docs/install.md
@@ -56,11 +56,24 @@ DATE_DEPOT_DEBUT=
 DATE_DEPOT_FIN=
 STATUTS_DOSSIERS=
 GROUPES_INSTRUCTEURS=
+
+# Flask
+FLASK_SECRET_KEY=
+# True = dev, False = prod
+FLASK_DEBUG=False
+
+DATABASE_URL=postgresql://user:password@host:port/db_name
+ENCRYPTION_KEY='encrypt-key'
 ```
 
 ### FLASK_SECRET_KEY
 
 1. Générer un secret pour flask : `poe generate-secret`
+2. Copier coller le retour de la commande dans `.env`
+
+### ENCRYPTION_KEY
+
+1. Générer un secret pour flask : `poe generate-encryption-key`
 2. Copier coller le retour de la commande dans `.env`
 
 # ▶️ Lancement de l'application

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,3 +39,8 @@ shell = "python app.py"
 [tool.poe.tasks.generate-secret]
 help = "Génère une clé secrète sécurisée pour Flask"
 shell = "python3 -c \"import secrets; print('FLASK_SECRET_KEY=' + secrets.token_hex(32))\""
+
+[tool.poe.tasks.generate-encryption-key]
+help = "Génère une clé secrète de cryptage"
+shell = "python3 -c \"import secrets, base64; print('ENCRYPTION_KEY=' + base64.urlsafe_b64encode(secrets.token_bytes(32)).decode())\""
+

--- a/templates/index.html
+++ b/templates/index.html
@@ -228,6 +228,10 @@
 
             const response = await fetch(`/api/config${gristParams}`);
             const config = await response.json();
+
+            if (!response.ok)
+              throw new Error(config.message)
+
             currentConfig = config;
 
             // Déterminer si une configuration a été trouvée pour ce contexte Grist


### PR DESCRIPTION
Si absente, la clé de cryptage était régénérée, ce qui provoquait une erreur de décryptage non gérée.
Désormais la clé de cryptage doit absolument être définit par la personne qui installe l'application.
L'erreur de cryptage est désormais interceptée et l'application communique l'information à l'utilisateur. 