### PR TITLE
fix(CI): Configure release-please action with token and changelog types

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,3 +12,19 @@ jobs:
         with:
           release-type: python
           default-branch: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+          changelog-types: |
+            [
+              {"type":"feat","section":"Nouveautés","hidden":false},
+              {"type":"improve","section":"Améliorations","hidden":false},
+              {"type":"fix","section":"Corrections (bugs, typos...)","hidden":false},
+              {"type":"docs","section":"Documentation","hidden":false},
+              {"type":"refactor","section":"Technique","hidden":false},
+              {"type":"revert","section":"Technique","hidden":false},
+              {"type":"style","section":"Technique","hidden":false},
+              {"type":"test","section":"Technique","hidden":false},
+              {"type":"chore","section":"Technique","hidden":false},
+              {"type":"perf","section":"Technique","hidden":false},
+              {"type":"build","section":"Technique","hidden":false},
+              {"type":"ci","section":"Technique","hidden":false}
+            ]


### PR DESCRIPTION
# Contexte
La CI tourne dès qu'on **push** sur la branche **main**

# Problème
Dès que release-please tour, nous avons l'erreur `Afin de réparer l'erreur dans la CI : `Error: release-please failed: Error creating Pull Request: Resource not accessible by integration`

# Solution
Ajouter une permission à Release Please, par exemple avec un token
ref:
* [Stack Overflow](https://stackoverflow.com/questions/70435286/resource-not-accessible-by-integration-on-github-post-repos-owner-repo-ac)
* config sur le projet [ma-cantine](https://github.com/betagouv/ma-cantine/blob/staging/.github/workflows/release-please.yml)
