### PR TITLE
fixes #45 Remove 'piece_justificative' from descriptor check

### DIFF
--- a/grist_processor_working_all.py
+++ b/grist_processor_working_all.py
@@ -395,8 +395,8 @@ def get_problematic_descriptor_ids(demarche_number):
     def explore_descriptors(descriptors):
         for descriptor in descriptors:
             # Ajouter si problématique
-            if (descriptor.get("type") in ["header_section", "explication", "piece_justificative"] or 
-                descriptor.get("__typename") in ["HeaderSectionChampDescriptor", "ExplicationChampDescriptor", "PieceJustificativeChampDescriptor"]):
+            if (descriptor.get("type") in ["header_section", "explication"] or 
+                descriptor.get("__typename") in ["HeaderSectionChampDescriptor", "ExplicationChampDescriptor"]):
                 problematic_ids.add(descriptor.get("id"))
             
             # Explorer récursivement les blocs répétables


### PR DESCRIPTION
Corrige le pb des données des pj RIB qui n'étaient pas implémentées dans les colonnes Grist.