### PR TITLE
fix: suppression fallback date_modif

### DIFF
--- a/grist_processor_working_all.py
+++ b/grist_processor_working_all.py
@@ -2864,54 +2864,6 @@ def process_demarche_for_grist_optimized(
         skip_dossiers = set()
         skip_champs = set()
         skip_annotations = set()
-        grist_dates = {}
-
-        if updated_since_cursor or force_full_sync:
-            log(
-                "updatedSince actif ou force_full_sync → comparaison de dates skippée (tous les dossiers listés sont potentiellement modifiés)"
-            )
-        else:
-            log("Construction des sets de skip par dates de modification...")
-            grist_dates = client.get_existing_dossier_dates(
-                table_ids["dossier_table_id"]
-            )
-
-        for dossier in filtered_dossiers:
-            num = str(dossier["number"])
-            grist = grist_dates.get(num)
-
-            if not grist:
-                continue  # nouveau dossier → upsert sur tout
-
-            ds_date = (dossier.get("dateDerniereModification") or "")[:19]
-            grist_date = (grist.get("date_derniere_modification") or "")[:19]
-
-            if not ds_date or not grist_date:
-                continue  # date manquante → forcer upsert par sécurité
-
-            if ds_date == grist_date:
-                # Dossier global inchangé → skip dossiers + demandeurs
-                skip_dossiers.add(num)
-
-                # Champs : date disponible seulement après fetch détail
-                # → on skippe uniquement si la date champs est aussi présente dans Grist
-                grist_date_champs = (
-                    grist.get("date_derniere_modification_champs") or ""
-                )[:19]
-                if grist_date_champs:
-                    skip_champs.add(num)
-
-                # Annotations : idem + vérifier que la table existe
-                if table_ids.get("annotations"):
-                    grist_date_annot = (
-                        grist.get("date_derniere_modification_annotations") or ""
-                    )[:19]
-                    if grist_date_annot:
-                        skip_annotations.add(num)
-
-        log(
-            f"Skip dossiers: {len(skip_dossiers)} | champs: {len(skip_champs)} | annotations: {len(skip_annotations)}"
-        )
 
         # Synchroniser les instructeurs UNE SEULE FOIS (niveau démarche)
         if table_ids.get("instructeurs"):


### PR DESCRIPTION
fix: suppression du fallback comparaison dates Grist → résout TypeError 'int' object is not subscriptable

## Problème
Quand les colonnes de dates (`date_derniere_modification`, 
`date_derniere_modification_champs`, `date_derniere_modification_annotations`) 
dans la table `Demarche_X_dossiers` sont converties en DateTime par Grist 
(automatiquement ou manuellement), les valeurs sont retournées comme des entiers 
Unix. Le code tentait alors de faire `[:19]` sur un entier, provoquant :

TypeError: 'int' object is not subscriptable

## Cause
Le fallback de comparaison de dates côté Grist était utilisé pour skiper les 
dossiers inchangés lors d'une sync sans curseur `updatedSince`. Ce mécanisme 
est fragile car il dépend du type des colonnes DateTime dans Grist.

## Solution
Suppression du fallback. Le curseur `updatedSince` côté DS assure déjà 
l'optimisation principale — seuls les dossiers modifiés depuis la dernière sync 
sont retournés par l'API DS. En sync complète, tous les dossiers sont upsertés 
(comportement attendu).

## Impact
- Sync incrémentale (`updatedSince`) : aucun impact, même comportement
- Sync complète (`force_full_sync` ou première sync) : tous les dossiers sont 
  upsertés, légère augmentation du temps de sync possible
- Plus aucun risque de TypeError lié aux types de colonnes Grist

## Fichiers modifiés
- `grist_processor_working_all.py` : suppression du bloc fallback dates + 
  variables inutilisées (`grist_dates`