### PR TITLE
fix: correction du comptage des dossiers synchronisés dans l'interface

### DIFF
--- a/static/js/logs.js
+++ b/static/js/logs.js
@@ -38,7 +38,6 @@ const extractStatsFromLog = (message) => {
 
     if (newTotal > totalDossiers) {
       totalDossiers = newTotal
-      console.log(`Total dossiers mis à jour: ${totalDossiers}`)
     }
   }
 
@@ -57,9 +56,6 @@ const extractStatsFromLog = (message) => {
       const lotSuccess = parseInt(resumeMatch[1])
       successCount += lotSuccess
       processedCountElement.textContent = successCount
-      console.log(
-        `Dossiers lot ajoutés: +${lotSuccess}, total: ${successCount}`
-      )
     }
   }
 
@@ -68,7 +64,6 @@ const extractStatsFromLog = (message) => {
     const newSuccess = parseInt(successMatch[1])
     successCount = newSuccess // Utiliser la valeur finale
     processedCountElement.textContent = successCount
-    console.log(`Succès final: ${successCount}`)
   }
 
   // Extraire le nombre d'erreurs/échecs
@@ -86,7 +81,6 @@ const extractStatsFromLog = (message) => {
     const newErrors = parseInt(errorMatch[1])
     if (newErrors > errorCount) {
       errorCount = newErrors
-      console.log(`Erreurs mises à jour: ${errorCount}`)
     }
   }
 
@@ -104,7 +98,6 @@ const extractStatsFromLog = (message) => {
       // Si moins de 80% récupérés, c'est problématique
       const failedCount = total - recovered
       errorCount = Math.max(errorCount, failedCount)
-      console.log(`Échecs détectés depuis taux de récupération: ${failedCount}`)
     }
   }
 
@@ -120,7 +113,6 @@ const extractStatsFromLog = (message) => {
     message.toLowerCase().includes('timeout')
   ) {
     errorCount++
-    console.log(`Erreur individuelle détectée, total erreurs: ${errorCount}`)
   }
 }
 

--- a/static/js/logs.js
+++ b/static/js/logs.js
@@ -11,10 +11,7 @@ const toggleLogs = (logsVisible) => {
     text.textContent = 'Masquer les logs'
 
     // Auto-scroll vers le bas
-    setTimeout(
-      () => container.scrollTop = container.scrollHeight
-      , 100
-    )
+    setTimeout(() => (container.scrollTop = container.scrollHeight), 100)
   } else {
     container.style.display = 'none'
     icon.className = 'fas fa-chevron-down fr-mr-1w'
@@ -28,139 +25,117 @@ const extractStatsFromLog = (message) => {
   const processedCountElement = document.getElementById('processed_count')
 
   // Extraire le nombre total de dossiers
-  let totalMatch = message.match(/Nombre total de dossiers trouvés:\s*(\d+)/i);
+  let totalMatch = message.match(/Nombre total de dossiers trouvés:\s*(\d+)/i)
 
   if (!totalMatch)
-    totalMatch = message.match(/Après filtrage:\s*(\d+)\s+dossiers/i);
+    totalMatch = message.match(/Après filtrage:\s*(\d+)\s+dossiers/i)
 
   if (!totalMatch)
-    totalMatch = message.match(/(\d+)\s+dossiers?\s+(?:trouvés?|à traiter)/i);
+    totalMatch = message.match(/(\d+)\s+dossiers?\s+(?:trouvés?|à traiter)/i)
 
   if (totalMatch) {
-    const newTotal = parseInt(totalMatch[1]);
+    const newTotal = parseInt(totalMatch[1])
 
     if (newTotal > totalDossiers) {
-      totalDossiers = newTotal;
-      console.log(`Total dossiers mis à jour: ${totalDossiers}`);
+      totalDossiers = newTotal
+      console.log(`Total dossiers mis à jour: ${totalDossiers}`)
     }
   }
 
   // NOUVELLE LOGIQUE : Extraire le nombre de dossiers traités avec succès
-  let successMatch = null;
+  let successMatch = null
 
   // 1. Rechercher le message final de succès
-  successMatch = message.match(/Dossiers traités avec succès:\s*(\d+)/i);
+  successMatch = message.match(/Dossiers traités avec succès:\s*(\d+)/i)
 
-  // 2. Rechercher les messages de lot de succès
+  // 2. Résumé upsert table dossiers uniquement
   if (!successMatch) {
-    const lotMatch = message.match(/Lot\s+\d+\s+terminé:\s*(\d+)\s+dossiers?\s+traités?\s+avec\s+succès/i);
-
-    if (lotMatch) {
-      const lotSuccess = parseInt(lotMatch[1]);
-      successCount += lotSuccess; // Additionner au lieu de remplacer
-      processedCountElement.textContent = successCount;
-      console.log(`Dossiers du lot ajoutés: +${lotSuccess}, total: ${successCount}`);
+    const resumeMatch = message.match(
+      /Résumé upsert table.*_dossiers.*:\s*(\d+)\s+succès/i
+    )
+    if (resumeMatch) {
+      const lotSuccess = parseInt(resumeMatch[1])
+      successCount += lotSuccess
+      processedCountElement.textContent = successCount
+      console.log(
+        `Dossiers lot ajoutés: +${lotSuccess}, total: ${successCount}`
+      )
     }
   }
 
-  // 3. Rechercher les messages de création/mise à jour réussies
-  if (!successMatch) {
-    // Upsert par lot réussi
-    const upsertMatch = message.match(/Upsert par lot de\s*(\d+)\s+dossiers.../i);
-    if (upsertMatch && !message.includes('ERREUR')) {
-      const upsertSuccess = parseInt(upsertMatch[1]);
-      successCount = Math.max(successCount, upsertSuccess);
-      processedCountElement.textContent = successCount;
-      console.log(`Upsert dossiers détecté: ${upsertSuccess}`);
-    }
-  }
-
-  // 4. Rechercher les créations par lot
-  if (!successMatch) {
-    const createMatch = message.match(/Création par lot:\s*(\d+)\s+enregistrements?\s+créés?\s+avec\s+succès/i);
-    if (createMatch) {
-      const createSuccess = parseInt(createMatch[1]);
-      successCount += createSuccess; // Additionner
-      processedCountElement.textContent = successCount;
-      console.log(`Créations ajoutées: +${createSuccess}, total: ${successCount}`);
-    }
-  }
-
-  // 5. Rechercher les mises à jour par lot
-  if (!successMatch) {
-    const updateMatch = message.match(/Mise à jour par lot:\s*(\d+)\s+enregistrements?\s+mis à jour avec succès/i);
-    if (updateMatch) {
-      const updateSuccess = parseInt(updateMatch[1]);
-      successCount += updateSuccess; // Additionner
-      processedCountElement.textContent = successCount;
-      console.log(`Mises à jour ajoutées: +${updateSuccess}, total: ${successCount}`);
-    }
-  }
-
-  // 6. Traitement du message final de succès (écrase le compteur)
+  // 3. Traitement du message final de succès (écrase le compteur)
   if (successMatch) {
-    const newSuccess = parseInt(successMatch[1]);
-    successCount = newSuccess; // Utiliser la valeur finale
-    processedCountElement.textContent = successCount;
-    console.log(`Succès final: ${successCount}`);
+    const newSuccess = parseInt(successMatch[1])
+    successCount = newSuccess // Utiliser la valeur finale
+    processedCountElement.textContent = successCount
+    console.log(`Succès final: ${successCount}`)
   }
 
   // Extraire le nombre d'erreurs/échecs
-  let errorMatch = message.match(/Dossiers en échec:\s*(\d+)/i);
-  if (!errorMatch)
-    errorMatch = message.match(/Échecs?:\s*(\d+)/i);
+  let errorMatch = message.match(/Dossiers en échec:\s*(\d+)/i)
+  if (!errorMatch) errorMatch = message.match(/Échecs?:\s*(\d+)/i)
+
+  if (!errorMatch) errorMatch = message.match(/(\d+)\s+erreurs?\s+détectées?/i)
 
   if (!errorMatch)
-    errorMatch = message.match(/(\d+)\s+erreurs?\s+détectées?/i);
-
-  if (!errorMatch)
-    errorMatch = message.match(/(\d+)\s+dossiers?\s+n'ont\s+pas\s+pu\s+être\s+récupérés/i);
+    errorMatch = message.match(
+      /(\d+)\s+dossiers?\s+n'ont\s+pas\s+pu\s+être\s+récupérés/i
+    )
 
   if (errorMatch) {
-    const newErrors = parseInt(errorMatch[1]);
+    const newErrors = parseInt(errorMatch[1])
     if (newErrors > errorCount) {
-      errorCount = newErrors;
-      console.log(`Erreurs mises à jour: ${errorCount}`);
+      errorCount = newErrors
+      console.log(`Erreurs mises à jour: ${errorCount}`)
     }
   }
 
   // Détecter les pourcentages de récupération faibles (signe d'erreurs)
-  let recoveryMatch = message.match(/(\d+)\/(\d+)\s+dossiers?\s+récupérés?\s+\((\d+(?:\.\d+)?)%\)/i);
+  let recoveryMatch = message.match(
+    /(\d+)\/(\d+)\s+dossiers?\s+récupérés?\s+\((\d+(?:\.\d+)?)%\)/i
+  )
 
   if (recoveryMatch) {
-    const recovered = parseInt(recoveryMatch[1]);
-    const total = parseInt(recoveryMatch[2]);
-    const percentage = parseFloat(recoveryMatch[3]);
+    const recovered = parseInt(recoveryMatch[1])
+    const total = parseInt(recoveryMatch[2])
+    const percentage = parseFloat(recoveryMatch[3])
 
-    if (percentage < 80) { // Si moins de 80% récupérés, c'est problématique
-      const failedCount = total - recovered;
-      errorCount = Math.max(errorCount, failedCount);
-      console.log(`Échecs détectés depuis taux de récupération: ${failedCount}`);
+    if (percentage < 80) {
+      // Si moins de 80% récupérés, c'est problématique
+      const failedCount = total - recovered
+      errorCount = Math.max(errorCount, failedCount)
+      console.log(`Échecs détectés depuis taux de récupération: ${failedCount}`)
     }
   }
 
   // Détecter les messages d'erreur individuels pour incrémenter le compteur
   if (
-    message.toLowerCase().includes('erreur lors de la récupération du dossier') ||
+    message
+      .toLowerCase()
+      .includes('erreur lors de la récupération du dossier') ||
     message.toLowerCase().includes('max retries exceeded') ||
     message.toLowerCase().includes('sslerror') ||
-    message.toLowerCase().includes('connection') && message.toLowerCase().includes('failed') ||
+    (message.toLowerCase().includes('connection') &&
+      message.toLowerCase().includes('failed')) ||
     message.toLowerCase().includes('timeout')
   ) {
-    errorCount++;
-    console.log(`Erreur individuelle détectée, total erreurs: ${errorCount}`);
+    errorCount++
+    console.log(`Erreur individuelle détectée, total erreurs: ${errorCount}`)
   }
 }
 
 const copyLogs = () => {
   const logsContent = document.getElementById('logs_content')
   const text = logsContent.textContent || logsContent.innerText
-  navigator.clipboard.writeText(text).then(() => {
-    showNotification('Logs copiés dans le presse-papiers', 'success')
-  }).catch(err => {
-    console.error('Erreur lors de la copie:', err)
-    showNotification('Erreur lors de la copie des logs', 'error')
-  })
+  navigator.clipboard
+    .writeText(text)
+    .then(() => {
+      showNotification('Logs copiés dans le presse-papiers', 'success')
+    })
+    .catch((err) => {
+      console.error('Erreur lors de la copie:', err)
+      showNotification('Erreur lors de la copie des logs', 'error')
+    })
 }
 
 if (typeof module !== 'undefined' && module.exports) {

--- a/tests/js/logs.test.js
+++ b/tests/js/logs.test.js
@@ -5,247 +5,218 @@ const {
   copyLogs
 } = require('../../static/js/logs.js')
 
-describe(
-  'toggleLogs',
-  () => {
-    beforeEach(() => {
-      // Setup DOM réel en jsdom
-      document.body.innerHTML = `
+describe('toggleLogs', () => {
+  beforeEach(() => {
+    // Setup DOM réel en jsdom
+    document.body.innerHTML = `
         <div id="logs_container" style="height: 300px; overflow-y: auto;"></div>
         <i id="logs_toggle_icon" class="fas fa-chevron-down fr-mr-1w"></i>
         <span id="logs_toggle_text">Afficher les logs</span>
         `
-      // Reset variable globale
+    // Reset variable globale
 
-      // Mock setTimeout pour contrôler le scroll
-      jest.useFakeTimers()
-    })
+    // Mock setTimeout pour contrôler le scroll
+    jest.useFakeTimers()
+  })
 
-    afterEach(() => {
-      jest.clearAllTimers()
-      jest.useRealTimers()
-    })
+  afterEach(() => {
+    jest.clearAllTimers()
+    jest.useRealTimers()
+  })
 
-    it('affiche les logs et scroll vers le bas', () => {
-      const container = document.getElementById('logs_container')
-      const icon = document.getElementById('logs_toggle_icon')
-      const text = document.getElementById('logs_toggle_text')
+  it('affiche les logs et scroll vers le bas', () => {
+    const container = document.getElementById('logs_container')
+    const icon = document.getElementById('logs_toggle_icon')
+    const text = document.getElementById('logs_toggle_text')
 
-      // Ajouter du contenu pour simuler scrollHeight > 0
-      container.innerHTML = '<div style="height: 600px;">Log content</div>'
+    // Ajouter du contenu pour simuler scrollHeight > 0
+    container.innerHTML = '<div style="height: 600px;">Log content</div>'
 
-      toggleLogs(false)
+    toggleLogs(false)
 
-      // expect(global.logsVisible).toBe(true)
-      expect(container.style.display).toBe('block')
-      expect(icon.className).toBe('fas fa-chevron-up fr-mr-1w')
-      expect(text.textContent).toBe('Masquer les logs')
+    // expect(global.logsVisible).toBe(true)
+    expect(container.style.display).toBe('block')
+    expect(icon.className).toBe('fas fa-chevron-up fr-mr-1w')
+    expect(text.textContent).toBe('Masquer les logs')
 
-      // Avancer les timers pour déclencher le scroll
-      jest.runAllTimers()
-      expect(container.scrollTop).toBe(container.scrollHeight)
-    })
+    // Avancer les timers pour déclencher le scroll
+    jest.runAllTimers()
+    expect(container.scrollTop).toBe(container.scrollHeight)
+  })
 
-    it('masque les logs', () => {
-      const container = document.getElementById('logs_container')
-      const icon = document.getElementById('logs_toggle_icon')
-      const text = document.getElementById('logs_toggle_text')
+  it('masque les logs', () => {
+    const container = document.getElementById('logs_container')
+    const icon = document.getElementById('logs_toggle_icon')
+    const text = document.getElementById('logs_toggle_text')
 
-      toggleLogs(true)
+    toggleLogs(true)
 
-      // expect(global.logsVisible).toBe(false)
-      expect(container.style.display).toBe('none')
-      expect(icon.className).toBe('fas fa-chevron-down fr-mr-1w')
-      expect(text.textContent).toBe('Afficher les logs')
-    }) 
-}
-)
+    // expect(global.logsVisible).toBe(false)
+    expect(container.style.display).toBe('none')
+    expect(icon.className).toBe('fas fa-chevron-down fr-mr-1w')
+    expect(text.textContent).toBe('Afficher les logs')
+  })
+})
 
-describe(
-  'extractStatsFromLog',
-  () => {
-    beforeEach(() => {
-      // Setup DOM simulé pour les éléments utilisés par extractStatsFromLog
-      document.body.innerHTML = ` <div id="processed_count">0</div>`
+describe('extractStatsFromLog', () => {
+  beforeEach(() => {
+    // Setup DOM simulé pour les éléments utilisés par extractStatsFromLog
+    document.body.innerHTML = ` <div id="processed_count">0</div>`
 
-      // Reset des variables globales
-      global.totalDossiers = 0
-      global.successCount = 0
-      global.errorCount = 0
+    // Reset des variables globales
+    global.totalDossiers = 0
+    global.successCount = 0
+    global.errorCount = 0
 
-      consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {}) // Supprime console.log
-
-      document.body.innerHTML = `
+    document.body.innerHTML = `
         <div id="processed_count">0</div>
         <div id="logs_count">0</div>`
-    })
+  })
 
-    afterEach(() => {
-      consoleLogSpy.mockRestore() // Restaure console.log
-    })
+  it('extract total number of "dossiers"', () => {
+    const nbDossiers = 150
+    // Setup : Mock des variables globales utilisées par la fonction
+    global.totalDossiers = 0
+    global.successCount = 0
+    global.errorCount = 0
 
-    it(
-      'extract total number of "dossiers"',
-      () => {
-        const nbDossiers = 150
-        // Setup : Mock des variables globales utilisées par la fonction
-        global.totalDossiers = 0
-        global.successCount = 0
-        global.errorCount = 0
+    const message = `Nombre total de dossiers trouvés: ${nbDossiers}`
 
-        const message = `Nombre total de dossiers trouvés: ${nbDossiers}`
+    extractStatsFromLog(message)
 
-        extractStatsFromLog(message)
+    expect(global.totalDossiers).toBe(150)
+    expect(global.successCount).toBe(0)
+    expect(global.errorCount).toBe(0)
+  })
 
-        expect(global.totalDossiers).toBe(150)
-        expect(global.successCount).toBe(0)
-        expect(global.errorCount).toBe(0)
-        expect(consoleLogSpy).toHaveBeenCalledWith(`Total dossiers mis à jour: ${nbDossiers}`)
-      }
+  it('extract number of succeded "dossiers"', () => {
+    const nbDossiers = 75
+
+    // Setup : Mock des variables globales
+    global.totalDossiers = 0
+    global.successCount = 0
+    global.errorCount = 0
+
+    const message = `Dossiers traités avec succès: ${nbDossiers}`
+
+    extractStatsFromLog(message)
+
+    expect(global.successCount).toBe(nbDossiers)
+    expect(global.totalDossiers).toBe(0)
+    expect(global.errorCount).toBe(0)
+    expect(document.getElementById('processed_count').textContent).toBe(
+      nbDossiers.toString()
     )
+  })
 
-    it(
-      'extract number of succeded "dossiers"',
-      () => {
-        const nbDossiers = 75
+  it('extract number of fail', () => {
+    const nbDossiers = 10
+    // Setup : Mock des variables globales et DOM (comme dans beforeEach)
+    global.totalDossiers = 0
+    global.successCount = 0
+    global.errorCount = 0
 
-        // Setup : Mock des variables globales
-        global.totalDossiers = 0
-        global.successCount = 0
-        global.errorCount = 0
+    const message = `Dossiers en échec: ${nbDossiers}`
 
-        const message = `Dossiers traités avec succès: ${nbDossiers}`
+    extractStatsFromLog(message)
 
-        extractStatsFromLog(message)
+    expect(global.errorCount).toBe(10)
+    expect(global.totalDossiers).toBe(0)
+    expect(global.successCount).toBe(0)
+  })
 
-        expect(global.successCount).toBe(nbDossiers)
-        expect(global.totalDossiers).toBe(0)
-        expect(global.errorCount).toBe(0)
-        expect(consoleLogSpy).toHaveBeenCalledWith(`Succès final: ${nbDossiers}`)
-        expect(document.getElementById('processed_count').textContent).toBe(nbDossiers.toString())
-      }
-    )
+  it('check ratio of fail', () => {
+    const nbDossiers = 50
+    // Setup : Mock des variables globales et DOM
+    global.totalDossiers = 0
+    global.successCount = 0
+    global.errorCount = 0
 
-    it(
-      'extract number of fail',
-      () => {
-        const nbDossiers = 10
-        // Setup : Mock des variables globales et DOM (comme dans beforeEach)
-        global.totalDossiers = 0
-        global.successCount = 0
-        global.errorCount = 0
+    const message = `${nbDossiers}/100 dossiers récupérés (50%)`
 
-        const message = `Dossiers en échec: ${nbDossiers}`
+    extractStatsFromLog(message)
 
-        extractStatsFromLog(message)
+    expect(global.errorCount).toBe(50)
+    expect(global.totalDossiers).toBe(0)
+    expect(global.successCount).toBe(0)
+  })
+})
 
-        expect(global.errorCount).toBe(10);
-        expect(global.totalDossiers).toBe(0)
-        expect(global.successCount).toBe(0)
-        expect(consoleLogSpy).toHaveBeenCalledWith(`Erreurs mises à jour: ${nbDossiers}`)
-      }
-    )
+describe('copyLogs', () => {
+  let clipboardWriteTextMock
+  let showNotificationMock
+  let consoleErrorSpy
 
-    it(
-      'check ratio of fail',
-      () => {
-        const nbDossiers = 50
-        // Setup : Mock des variables globales et DOM
-        global.totalDossiers = 0
-        global.successCount = 0
-        global.errorCount = 0
-
-        const message = `${nbDossiers}/100 dossiers récupérés (50%)`
-
-        extractStatsFromLog(message)
-
-        expect(global.errorCount).toBe(50)
-        expect(global.totalDossiers).toBe(0)
-        expect(global.successCount).toBe(0)
-        expect(consoleLogSpy).toHaveBeenCalledWith(`Échecs détectés depuis taux de récupération: ${nbDossiers}`)
-      }
-    )
-  }
-)
-
-describe(
-  'copyLogs',
-  () => {
-    let clipboardWriteTextMock
-    let showNotificationMock
-    let consoleErrorSpy
-
-    beforeEach(() => {
-      // Setup DOM
-      document.body.innerHTML = `
+  beforeEach(() => {
+    // Setup DOM
+    document.body.innerHTML = `
         <div id="logs_content">Sample log text</div>
       `
 
-      // Mock navigator.clipboard
-      clipboardWriteTextMock = jest.fn()
-      Object.defineProperty(navigator, 'clipboard', {
-        value: { writeText: clipboardWriteTextMock },
-        writable: true
-      })
-
-      // Mock showNotification
-      showNotificationMock = jest.fn()
-      global.showNotification = showNotificationMock
-
-      // Spy on console.error
-      consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    // Mock navigator.clipboard
+    clipboardWriteTextMock = jest.fn()
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: clipboardWriteTextMock },
+      writable: true
     })
 
-    afterEach(() => {
-      consoleErrorSpy.mockRestore()
-      jest.restoreAllMocks()
-    })
+    // Mock showNotification
+    showNotificationMock = jest.fn()
+    global.showNotification = showNotificationMock
 
-    it(
-      'copies logs text to clipboard successfully',
-      async () => {
-        clipboardWriteTextMock.mockResolvedValue()
+    // Spy on console.error
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+  })
 
-        copyLogs()
+  afterEach(() => {
+    consoleErrorSpy.mockRestore()
+    jest.restoreAllMocks()
+  })
 
-        await new Promise(resolve => setTimeout(resolve, 0)) // Wait for promise
+  it('copies logs text to clipboard successfully', async () => {
+    clipboardWriteTextMock.mockResolvedValue()
 
-        expect(clipboardWriteTextMock).toHaveBeenCalledWith('Sample log text')
-        expect(showNotificationMock).toHaveBeenCalledWith('Logs copiés dans le presse-papiers', 'success')
-        expect(consoleErrorSpy).not.toHaveBeenCalled()
-      }
+    copyLogs()
+
+    await new Promise((resolve) => setTimeout(resolve, 0)) // Wait for promise
+
+    expect(clipboardWriteTextMock).toHaveBeenCalledWith('Sample log text')
+    expect(showNotificationMock).toHaveBeenCalledWith(
+      'Logs copiés dans le presse-papiers',
+      'success'
     )
+    expect(consoleErrorSpy).not.toHaveBeenCalled()
+  })
 
-    it(
-      'handles clipboard copy error',
-      async () => {
-        const error = new Error('Clipboard error')
-        clipboardWriteTextMock.mockRejectedValue(error)
+  it('handles clipboard copy error', async () => {
+    const error = new Error('Clipboard error')
+    clipboardWriteTextMock.mockRejectedValue(error)
 
-        copyLogs()
+    copyLogs()
 
-        await new Promise(resolve => setTimeout(resolve, 0)) // Wait for promise
+    await new Promise((resolve) => setTimeout(resolve, 0)) // Wait for promise
 
-        expect(clipboardWriteTextMock).toHaveBeenCalledWith('Sample log text')
-        expect(showNotificationMock).toHaveBeenCalledWith('Erreur lors de la copie des logs', 'error')
-        expect(consoleErrorSpy).toHaveBeenCalledWith('Erreur lors de la copie:', error)
-      }
+    expect(clipboardWriteTextMock).toHaveBeenCalledWith('Sample log text')
+    expect(showNotificationMock).toHaveBeenCalledWith(
+      'Erreur lors de la copie des logs',
+      'error'
     )
-
-    it(
-      'uses textContent if innerText is not available',
-      () => {
-        // textContent and innerText are similar in jsdom, but test fallback
-        const logsElement = document.getElementById('logs_content')
-        logsElement.textContent = 'Text content'
-        logsElement.innerText = '' // Simulate no innerText
-
-        clipboardWriteTextMock.mockResolvedValue()
-
-        copyLogs()
-
-        expect(clipboardWriteTextMock).toHaveBeenCalledWith('Text content')
-      }
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Erreur lors de la copie:',
+      error
     )
-  }
-)
+  })
+
+  it('uses textContent if innerText is not available', () => {
+    // textContent and innerText are similar in jsdom, but test fallback
+    const logsElement = document.getElementById('logs_content')
+    logsElement.textContent = 'Text content'
+    logsElement.innerText = '' // Simulate no innerText
+
+    clipboardWriteTextMock.mockResolvedValue()
+
+    copyLogs()
+
+    expect(clipboardWriteTextMock).toHaveBeenCalledWith('Text content')
+  })
+})


### PR DESCRIPTION
## Problème
Le compteur "Dossiers déposés synchronisés" affichait un nombre très supérieur 
au nombre réel de dossiers traités.

## Cause
La fonction `extractStatsFromLog` dans `logs.js` additionnait les upserts de 
toutes les tables (dossiers + champs + annotations + demandeurs), multipliant 
le compteur par le nombre de tables.

## Solution
Remplacement des patterns 3, 4, 5 par un seul pattern ciblant uniquement 
la table dossiers :
`Résumé upsert table.*_dossiers.*: X succès`

Suppression du pattern "Lot X terminé" qui doublonnait avec le nouveau pattern.

## Fichiers modifiés
- `static/js/logs.js`