### PR TITLE
fix: suffixes stables pour les champs en doublon via champDescriptorId

### DIFF
--- a/grist_processor_working_all.py
+++ b/grist_processor_working_all.py
@@ -14,7 +14,8 @@ import requests
 from dotenv import load_dotenv
 
 import repetable_processor as rp
-from queries import dossier_to_flat_data, get_demarche, get_dossier
+from queries import get_demarche, get_dossier
+from queries_extract import dossier_to_flat_data
 from queries_graphql import get_demarche_dossiers_filtered
 from queries_util import get_timings
 from schema_utils import (

--- a/grist_processor_working_all.py
+++ b/grist_processor_working_all.py
@@ -2530,6 +2530,8 @@ def process_demarche_for_grist_optimized(
         log(f"Dossiers organisés en {batch_count} lots de {batch_size} maximum")
 
         # Fonction pour préparer un seul dossier (DÉFINIE AVANT LA BOUCLE)
+        descriptor_to_column_id = column_types.get("descriptor_to_column_id", {})
+
         def prepare_single_dossier(
             dossier_num, dossier_data, column_types, problematic_descriptor_ids
         ):
@@ -2540,6 +2542,7 @@ def process_demarche_for_grist_optimized(
                     dossier_data,
                     exclude_repetition_champs=exclude_repetition,
                     problematic_ids=problematic_descriptor_ids,
+                    descriptor_to_column_id=descriptor_to_column_id,
                 )
 
                 # Préparer dossier_record

--- a/queries_extract.py
+++ b/queries_extract.py
@@ -5,8 +5,8 @@ from typing import Any, Dict, List
 
 import requests
 
-from utils.formatter import unwrap_json_list
 from utils.constants import DEMARCHES_API_URL
+from utils.formatter import unwrap_json_list
 
 API_TOKEN = os.getenv("DEMARCHES_API_TOKEN")
 API_URL = DEMARCHES_API_URL
@@ -854,7 +854,10 @@ def extract_instructeurs_from_demarche(demarche_number: int) -> List[Dict[str, A
 
 
 def dossier_to_flat_data(
-    dossier_data: Dict[str, Any], exclude_repetition_champs=True, problematic_ids=None
+    dossier_data: Dict[str, Any],
+    exclude_repetition_champs=True,
+    problematic_ids=None,
+    descriptor_to_column_id=None,
 ) -> Dict[str, Any]:
     """
     Transforme les données d'un dossier en un format plat pour faciliter l'intégration.
@@ -864,6 +867,7 @@ def dossier_to_flat_data(
         dossier_data: Données du dossier récupérées via l'API
         exclude_repetition_champs: Si True, exclut les blocs répétables des champs standards
         problematic_ids: Set des IDs de descripteurs problématiques à filtrer
+        descriptor_to_column_id: Mapping stable {descriptor_id: colonne_id} issu du schéma DS
 
     Returns:
         Dictionnaire avec les données du dossier en format plat
@@ -947,16 +951,19 @@ def dossier_to_flat_data(
 
         # Appliquer les suffixes pour les doublons
         for item in extracted:
-            base_label = item["base_label"]
-            normalized = normalize_column_name(base_label)
-
-            # Gérer les doublons
-            if normalized in label_counters:
-                label_counters[normalized] += 1
-                item["label"] = f"{base_label}_{label_counters[normalized]}"
+            descriptor_id = item.get("descriptor_id")
+            if descriptor_to_column_id and descriptor_id in descriptor_to_column_id:
+                item["label"] = descriptor_to_column_id[descriptor_id]
             else:
-                label_counters[normalized] = 0
-                item["label"] = base_label
+                base_label = item["base_label"]
+                normalized = normalize_column_name(base_label)
+                if normalized not in label_counters:
+                    label_counters[normalized] = {}
+                descriptor_map = label_counters[normalized]
+                if descriptor_id not in descriptor_map:
+                    descriptor_map[descriptor_id] = len(descriptor_map)
+                suffix = descriptor_map[descriptor_id]
+                item["label"] = base_label if suffix == 0 else f"{base_label}_{suffix}"
 
         champ_values.extend(extracted)
 
@@ -981,31 +988,29 @@ def dossier_to_flat_data(
 
         # Appliquer les suffixes pour les doublons
         for item in extracted:
-            base_label = item["base_label"]
-            # Enlever le préfixe "annotation_" si présent pour la normalisation
-            label_for_normalization = base_label
-            if label_for_normalization.startswith("annotation_"):
-                label_for_normalization = label_for_normalization[11:]
-
-            normalized = normalize_column_name(label_for_normalization)
-
-            # Gérer les doublons
-            if normalized in annotation_label_counters:
-                annotation_label_counters[normalized] += 1
-                # Reconstruire le label avec annotation_ et le suffixe
-                if base_label.startswith("annotation_"):
-                    item["label"] = (
-                        f"{base_label}_{annotation_label_counters[normalized]}"
-                    )
-                else:
-                    item["label"] = (
-                        f"annotation_{base_label}_{annotation_label_counters[normalized]}"
-                    )
+            descriptor_id = item.get("descriptor_id")
+            if descriptor_to_column_id and descriptor_id in descriptor_to_column_id:
+                item["label"] = f"annotation_{descriptor_to_column_id[descriptor_id]}"
             else:
-                annotation_label_counters[normalized] = 0
-                # Garder le label tel quel (avec annotation_ si déjà présent)
-                if not base_label.startswith("annotation_"):
-                    item["label"] = f"annotation_{base_label}"
+                base_label = item["base_label"]
+                label_for_normalization = base_label
+                if label_for_normalization.startswith("annotation_"):
+                    label_for_normalization = label_for_normalization[11:]
+                normalized = normalize_column_name(label_for_normalization)
+                if normalized not in annotation_label_counters:
+                    annotation_label_counters[normalized] = {}
+                descriptor_map = annotation_label_counters[normalized]
+                if descriptor_id not in descriptor_map:
+                    descriptor_map[descriptor_id] = len(descriptor_map)
+                suffix = descriptor_map[descriptor_id]
+                base_with_prefix = (
+                    base_label
+                    if base_label.startswith("annotation_")
+                    else f"annotation_{base_label}"
+                )
+                item["label"] = (
+                    base_with_prefix if suffix == 0 else f"{base_with_prefix}_{suffix}"
+                )
 
         annotation_values.extend(extracted)
 

--- a/schema_utils.py
+++ b/schema_utils.py
@@ -532,6 +532,7 @@ def create_columns_from_schema(demarche_schema, demarche_number=None):
     has_repetable_blocks = False
     repetable_blocks = {}  # NOUVEAU : Dict au lieu d'une seule liste
     has_carto_fields = False
+    descriptor_to_column_id = {}  # {descriptor_id: colonne_id_suffixée stable}
 
     # Traiter les descripteurs de champs
     if demarche_schema.get("activeRevision") and demarche_schema["activeRevision"].get(
@@ -679,6 +680,7 @@ def create_columns_from_schema(demarche_schema, demarche_number=None):
                     counter += 1
 
                 # ✅ FORMAT AVEC FIELDS
+                descriptor_to_column_id[descriptor.get("id")] = normalized_label
                 champ_columns.append(
                     {
                         "id": normalized_label,
@@ -905,6 +907,7 @@ def create_columns_from_schema(demarche_schema, demarche_number=None):
                 counter += 1
 
             # ✅ FORMAT AVEC FIELDS
+            descriptor_to_column_id[descriptor.get("id")] = annotation_label
             annotation_columns.append(
                 {
                     "id": annotation_label,
@@ -919,6 +922,7 @@ def create_columns_from_schema(demarche_schema, demarche_number=None):
         "annotations": annotation_columns,
         "has_repetable_blocks": has_repetable_blocks,
         "has_carto_fields": has_carto_fields,
+        "descriptor_to_column_id": descriptor_to_column_id,
     }
 
     if has_repetable_blocks:

--- a/tests/python/unit/sync/test_duplicate_labels.py
+++ b/tests/python/unit/sync/test_duplicate_labels.py
@@ -1,0 +1,177 @@
+import os
+import sys
+
+sys.path.insert(
+    0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "..", "..")
+)
+
+
+def make_champ(label, typename, descriptor_id, value=None, checked=None, selected=None):
+    """Fabrique un champ DS minimal."""
+    champ = {
+        "__typename": typename,
+        "id": f"id_{descriptor_id}",
+        "champDescriptorId": descriptor_id,
+        "label": label,
+        "updatedAt": "2024-01-01T00:00:00Z",
+        "prefilled": False,
+    }
+    if typename == "TextChamp":
+        champ["stringValue"] = value or ""
+    elif typename == "CheckboxChamp":
+        champ["checked"] = checked if checked is not None else False
+    elif typename == "YesNoChamp":
+        champ["selected"] = selected
+    return champ
+
+
+def make_dossier(champs, annotations=None):
+    """Fabrique un dossier DS minimal."""
+    return {
+        "id": "dossier_1",
+        "number": 1,
+        "state": "accepte",
+        "dateDepot": "2024-01-01T00:00:00Z",
+        "dateDerniereModification": "2024-01-01T00:00:00Z",
+        "dateDerniereModificationChamps": None,
+        "dateDerniereModificationAnnotations": None,
+        "datePassageEnConstruction": None,
+        "datePassageEnInstruction": None,
+        "dateExpiration": None,
+        "dateTraitement": None,
+        "dateSuppressionParUsager": None,
+        "dateAccuseLectureAgreement": None,
+        "labels": [],
+        "champs": champs,
+        "annotations": annotations or [],
+        "avis": [],
+        "usager": {"email": "test@test.fr"},
+        "demandeur": None,
+        "prenomMandataire": "",
+        "nomMandataire": "",
+        "deposeParUnTiers": False,
+    }
+
+
+class TestDuplicateLabelSuffixes:
+    def _get_labels(self, dossier, descriptor_to_column_id=None):
+        """Retourne la liste des labels produits par dossier_to_flat_data."""
+        from queries_extract import dossier_to_flat_data
+
+        flat = dossier_to_flat_data(
+            dossier,
+            exclude_repetition_champs=True,
+            descriptor_to_column_id=descriptor_to_column_id,
+        )
+        return [item["label"] for item in flat["champs"]]
+
+    def test_no_duplicate_no_suffix(self):
+        """Un champ unique ne doit pas être suffixé."""
+        dossier = make_dossier(
+            [
+                make_champ("Nom", "TextChamp", "desc_001", value="Martin"),
+            ]
+        )
+        labels = self._get_labels(dossier)
+        assert "Nom" in labels
+        assert "Nom_1" not in labels
+
+    def test_two_duplicates_get_suffixes(self):
+        """Deux champs avec le même label → premier sans suffixe, second avec _1."""
+        dossier = make_dossier(
+            [
+                make_champ("Nom", "TextChamp", "desc_001", value="Martin"),
+                make_champ("Nom", "TextChamp", "desc_002", value="Dupont"),
+            ]
+        )
+        labels = self._get_labels(dossier)
+        assert "Nom" in labels
+        assert "Nom_1" in labels
+
+    def test_suffix_stable_regardless_of_order(self):
+        """
+        Le suffixe doit être basé sur champDescriptorId, pas sur l'ordre.
+        Le mapping descriptor_to_column_id (issu du schéma DS) garantit
+        que desc_001 → "Nom" et desc_002 → "Nom_1" quel que soit l'ordre.
+        """
+        from queries_extract import dossier_to_flat_data
+
+        descriptor_to_column_id = {
+            "desc_001": "Nom",
+            "desc_002": "Nom_1",
+        }
+
+        dossier_a = make_dossier(
+            [
+                make_champ("Nom", "TextChamp", "desc_001", value="Martin"),
+                make_champ("Nom", "TextChamp", "desc_002", value="Dupont"),
+            ]
+        )
+        flat_a = dossier_to_flat_data(
+            dossier_a,
+            exclude_repetition_champs=True,
+            descriptor_to_column_id=descriptor_to_column_id,
+        )
+        labels_a = {item["label"]: item["value"] for item in flat_a["champs"]}
+
+        dossier_b = make_dossier(
+            [
+                make_champ("Nom", "TextChamp", "desc_002", value="Dupont"),
+                make_champ("Nom", "TextChamp", "desc_001", value="Martin"),
+            ]
+        )
+        flat_b = dossier_to_flat_data(
+            dossier_b,
+            exclude_repetition_champs=True,
+            descriptor_to_column_id=descriptor_to_column_id,
+        )
+        labels_b = {item["label"]: item["value"] for item in flat_b["champs"]}
+
+        assert labels_a.get("Nom") == "Martin"
+        assert labels_b.get("Nom") == "Martin"
+        assert labels_a.get("Nom_1") == "Dupont"
+        assert labels_b.get("Nom_1") == "Dupont"
+
+    def test_three_duplicates(self):
+        """Trois champs identiques → Nom, Nom_1, Nom_2."""
+        dossier = make_dossier(
+            [
+                make_champ("Nom", "TextChamp", "desc_001", value="A"),
+                make_champ("Nom", "TextChamp", "desc_002", value="B"),
+                make_champ("Nom", "TextChamp", "desc_003", value="C"),
+            ]
+        )
+        labels = self._get_labels(dossier)
+        assert "Nom" in labels
+        assert "Nom_1" in labels
+        assert "Nom_2" in labels
+
+    def test_different_labels_not_affected(self):
+        """Des champs avec des labels différents ne doivent pas être suffixés."""
+        dossier = make_dossier(
+            [
+                make_champ("Nom", "TextChamp", "desc_001", value="Martin"),
+                make_champ("Prénom", "TextChamp", "desc_002", value="Jean"),
+            ]
+        )
+        labels = self._get_labels(dossier)
+        assert "Nom" in labels
+        assert "Prénom" in labels
+        assert "Nom_1" not in labels
+        assert "Prénom_1" not in labels
+
+    def test_annotation_duplicates(self):
+        """Les annotations en doublon doivent aussi être gérées stablement."""
+        from queries_extract import dossier_to_flat_data
+
+        dossier = make_dossier(
+            champs=[],
+            annotations=[
+                make_champ("Avis", "TextChamp", "desc_010", value="OK"),
+                make_champ("Avis", "TextChamp", "desc_011", value="KO"),
+            ],
+        )
+        flat = dossier_to_flat_data(dossier, exclude_repetition_champs=True)
+        labels = [item["label"] for item in flat["annotations"]]
+        assert "annotation_Avis" in labels
+        assert "annotation_Avis_1" in labels

--- a/tests/python/unit/test_queries_extract.py
+++ b/tests/python/unit/test_queries_extract.py
@@ -1,0 +1,161 @@
+import os
+import sys
+
+sys.path.insert(
+    0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "..", "..")
+)
+
+from queries_extract import dossier_to_flat_data
+
+
+def make_champ(label, typename, descriptor_id, value=None, checked=None, selected=None):
+    """Fabrique un champ DS minimal."""
+    champ = {
+        "__typename": typename,
+        "id": f"id_{descriptor_id}",
+        "champDescriptorId": descriptor_id,
+        "label": label,
+        "updatedAt": "2024-01-01T00:00:00Z",
+        "prefilled": False,
+    }
+    if typename == "TextChamp":
+        champ["stringValue"] = value or ""
+    elif typename == "CheckboxChamp":
+        champ["checked"] = checked if checked is not None else False
+    elif typename == "YesNoChamp":
+        champ["selected"] = selected
+    return champ
+
+
+def make_dossier(champs, annotations=None):
+    """Fabrique un dossier DS minimal."""
+    return {
+        "id": "dossier_1",
+        "number": 1,
+        "state": "accepte",
+        "dateDepot": "2024-01-01T00:00:00Z",
+        "dateDerniereModification": "2024-01-01T00:00:00Z",
+        "dateDerniereModificationChamps": None,
+        "dateDerniereModificationAnnotations": None,
+        "datePassageEnConstruction": None,
+        "datePassageEnInstruction": None,
+        "dateExpiration": None,
+        "dateTraitement": None,
+        "dateSuppressionParUsager": None,
+        "dateAccuseLectureAgreement": None,
+        "labels": [],
+        "champs": champs,
+        "annotations": annotations or [],
+        "avis": [],
+        "usager": {"email": "test@test.fr"},
+        "demandeur": None,
+        "prenomMandataire": "",
+        "nomMandataire": "",
+        "deposeParUnTiers": False,
+    }
+
+
+class TestDossierToFlatDataDuplicateLabels:
+    """Tests sur la gestion des champs en doublon dans dossier_to_flat_data."""
+
+    def _get_labels(self, dossier, descriptor_to_column_id=None):
+        flat = dossier_to_flat_data(
+            dossier,
+            exclude_repetition_champs=True,
+            descriptor_to_column_id=descriptor_to_column_id,
+        )
+        return [item["label"] for item in flat["champs"]]
+
+    def test_no_duplicate_no_suffix(self):
+        """Un champ unique ne doit pas être suffixé."""
+        dossier = make_dossier([
+            make_champ("Nom", "TextChamp", "desc_001", value="Martin"),
+        ])
+        labels = self._get_labels(dossier)
+        assert "Nom" in labels
+        assert "Nom_1" not in labels
+
+    def test_two_duplicates_get_suffixes(self):
+        """Deux champs avec le même label → premier sans suffixe, second avec _1."""
+        dossier = make_dossier([
+            make_champ("Nom", "TextChamp", "desc_001", value="Martin"),
+            make_champ("Nom", "TextChamp", "desc_002", value="Dupont"),
+        ])
+        labels = self._get_labels(dossier)
+        assert "Nom" in labels
+        assert "Nom_1" in labels
+
+    def test_suffix_stable_regardless_of_order(self):
+        """
+        Avec le mapping du schéma DS, desc_001 → "Nom" et desc_002 → "Nom_1"
+        quel que soit l'ordre d'apparition dans les dossiers.
+        """
+        descriptor_to_column_id = {
+            "desc_001": "Nom",
+            "desc_002": "Nom_1",
+        }
+
+        dossier_a = make_dossier([
+            make_champ("Nom", "TextChamp", "desc_001", value="Martin"),
+            make_champ("Nom", "TextChamp", "desc_002", value="Dupont"),
+        ])
+        flat_a = dossier_to_flat_data(
+            dossier_a,
+            exclude_repetition_champs=True,
+            descriptor_to_column_id=descriptor_to_column_id,
+        )
+        labels_a = {item["label"]: item["value"] for item in flat_a["champs"]}
+
+        dossier_b = make_dossier([
+            make_champ("Nom", "TextChamp", "desc_002", value="Dupont"),
+            make_champ("Nom", "TextChamp", "desc_001", value="Martin"),
+        ])
+        flat_b = dossier_to_flat_data(
+            dossier_b,
+            exclude_repetition_champs=True,
+            descriptor_to_column_id=descriptor_to_column_id,
+        )
+        labels_b = {item["label"]: item["value"] for item in flat_b["champs"]}
+
+        assert labels_a.get("Nom") == "Martin"
+        assert labels_b.get("Nom") == "Martin"
+        assert labels_a.get("Nom_1") == "Dupont"
+        assert labels_b.get("Nom_1") == "Dupont"
+
+    def test_three_duplicates(self):
+        """Trois champs identiques → Nom, Nom_1, Nom_2."""
+        dossier = make_dossier([
+            make_champ("Nom", "TextChamp", "desc_001", value="A"),
+            make_champ("Nom", "TextChamp", "desc_002", value="B"),
+            make_champ("Nom", "TextChamp", "desc_003", value="C"),
+        ])
+        labels = self._get_labels(dossier)
+        assert "Nom" in labels
+        assert "Nom_1" in labels
+        assert "Nom_2" in labels
+
+    def test_different_labels_not_affected(self):
+        """Des champs avec des labels différents ne doivent pas être suffixés."""
+        dossier = make_dossier([
+            make_champ("Nom", "TextChamp", "desc_001", value="Martin"),
+            make_champ("Prénom", "TextChamp", "desc_002", value="Jean"),
+        ])
+        labels = self._get_labels(dossier)
+        assert "Nom" in labels
+        assert "Prénom" in labels
+        assert "Nom_1" not in labels
+        assert "Prénom_1" not in labels
+
+    def test_annotation_duplicates(self):
+        """Les annotations en doublon doivent aussi être gérées stablement."""
+        dossier = make_dossier(
+            champs=[],
+            annotations=[
+                make_champ("Avis", "TextChamp", "desc_010", value="OK"),
+                make_champ("Avis", "TextChamp", "desc_011", value="KO"),
+            ],
+        )
+        flat = dossier_to_flat_data(dossier, exclude_repetition_champs=True)
+        labels = [item["label"] for item in flat["annotations"]]
+        assert "annotation_Avis" in labels
+        assert "annotation_Avis_1" in labels


### PR DESCRIPTION
#356 

Correction du bug où deux champs conditionnels avec le même label 
produisaient des colonnes Grist instables selon l'ordre d'apparition 
dans les dossiers.

Le mapping {champDescriptorId → colonne_id} est désormais construit 
une seule fois depuis le schéma DS (create_columns_from_schema) et 
transmis à dossier_to_flat_data, garantissant que le même descripteur 
produit toujours le même identifiant de colonne quel que soit l'ordre 
d'apparition dans les dossiers.

Un fallback basé sur l'ordre d'apparition reste actif si le schéma 
n'est pas disponible.

6 tests unitaires ajoutés pour couvrir les cas de doublons.