### PR TITLE
feat: masquage automatique des colonnes _id dans Grist

### DIFF
--- a/grist_processor_working_all.py
+++ b/grist_processor_working_all.py
@@ -3179,6 +3179,15 @@ def process_demarche_for_grist_optimized(
         except Exception as e:
             log_error(f"Erreur sauvegarde Sync_metadata: {e}")
 
+        if schema_method_successful:
+            try:
+                from hide_id_columns import IdColumnHider
+
+                hider = IdColumnHider(client.base_url, client.api_key, client.doc_id)
+                hider.hide_id_columns()
+            except Exception as e:
+                log_error(f"Erreur lors du masquage des colonnes _id: {e}")
+
         return total_success > 0 or schema_method_successful
 
     except Exception as e:

--- a/hide_id_columns.py
+++ b/hide_id_columns.py
@@ -1,0 +1,139 @@
+# -*- coding: utf-8 -*-
+"""
+Scanne toutes les tables du doc Grist et cache, dans la première section
+de chaque table, toutes les colonnes dont le colId se termine par _id.
+
+Utilise les mêmes variables d'environnement que le reste du projet OTP :
+GRIST_BASE_URL, GRIST_API_KEY, GRIST_DOC_ID (chargées via .env).
+
+Usage :
+    python hide_id_columns.py
+"""
+
+import os
+import sys
+
+import requests
+from dotenv import load_dotenv
+
+
+def log(message, level=1, log_level=1):
+    if level <= log_level:
+        print(message)
+
+
+def log_error(message):
+    print(f"ERREUR: {message}")
+
+
+class IdColumnHider:
+    def __init__(self, base_url, api_key, doc_id):
+        base_url = base_url.rstrip("/")
+        # GRIST_BASE_URL peut ou non inclure déjà le suffixe /api selon la source
+        self.base_url = base_url[:-4] if base_url.endswith("/api") else base_url
+        self.doc_id = doc_id
+        self.headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+
+    def _api_url(self, path):
+        return f"{self.base_url}/api/docs/{self.doc_id}/{path}"
+
+    def _fetch(self, path):
+        resp = requests.get(self._api_url(path), headers=self.headers)
+        resp.raise_for_status()
+        return resp.json()["records"]
+
+    def _hide_field(self, field_id):
+        resp = requests.delete(
+            self._api_url("tables/_grist_Views_section_field/records"),
+            headers=self.headers,
+            json={"records": [{"id": field_id}]},
+        )
+        if resp.status_code in (404, 405):
+            resp = requests.post(
+                self._api_url("apply"),
+                headers=self.headers,
+                json=[["RemoveRecord", "_grist_Views_section_field", field_id]],
+            )
+        resp.raise_for_status()
+
+    def hide_id_columns(self, suffix="_id"):
+        """
+        Cache dans la première section de chaque table toutes les colonnes
+        dont le colId se termine par `suffix`. Retourne (nb_ok, nb_skip).
+        """
+        tables = {
+            r["id"]: r["fields"]["tableId"]
+            for r in self._fetch("tables/_grist_Tables/records")
+        }
+        columns = self._fetch("tables/_grist_Tables_column/records")
+        sections = self._fetch("tables/_grist_Views_section/records")
+        fields = self._fetch("tables/_grist_Views_section_field/records")
+
+        # Index : tableRef -> première section
+        first_section = {}
+        for r in sections:
+            t = r["fields"].get("tableRef")
+            if t and t not in first_section:
+                first_section[t] = r["id"]
+
+        # Index : (section_id, col_ref) -> field_id
+        field_index = {}
+        for r in fields:
+            key = (r["fields"].get("parentId"), r["fields"].get("colRef"))
+            field_index[key] = r["id"]
+
+        nb_ok = 0
+        nb_skip = 0
+
+        for col in columns:
+            col_id = col["fields"].get("colId", "")
+            if not col_id.endswith(suffix):
+                continue
+
+            table_ref = col["fields"].get("parentId")
+            table_name = tables.get(table_ref, f"tableRef={table_ref}")
+            col_ref = col["id"]
+            section_id = first_section.get(table_ref)
+
+            if section_id is None:
+                log(f"[SKIP] {table_name}.{col_id} — aucune section trouvée")
+                nb_skip += 1
+                continue
+
+            field_id = field_index.get((section_id, col_ref))
+            if field_id is None:
+                log(f"[SKIP] {table_name}.{col_id} — déjà cachée ou absente")
+                nb_skip += 1
+                continue
+
+            self._hide_field(field_id)
+            log(f"[OK]   {table_name}.{col_id} cachée (section {section_id})")
+            nb_ok += 1
+
+        return nb_ok, nb_skip
+
+
+def main():
+    load_dotenv(override=True)
+
+    grist_base_url = os.getenv("GRIST_BASE_URL")
+    grist_api_key = os.getenv("GRIST_API_KEY")
+    grist_doc_id = os.getenv("GRIST_DOC_ID")
+
+    if not all([grist_base_url, grist_api_key, grist_doc_id]):
+        log_error("Configuration Grist incomplète dans le fichier .env")
+        log("Assurez-vous d'avoir défini GRIST_BASE_URL, GRIST_API_KEY et GRIST_DOC_ID")
+        return 1
+
+    hider = IdColumnHider(grist_base_url, grist_api_key, grist_doc_id)
+    nb_ok, nb_skip = hider.hide_id_columns()
+
+    log(f"\nTerminé : {nb_ok} colonne(s) cachée(s), {nb_skip} ignorée(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Contexte
Les colonnes techniques `_id` (dossier_id, groupe_instructeur_id, etc.) sont créées automatiquement par le schéma DS et polluent l'affichage des tables Grist pour les utilisateurs finaux.

## Changements
- Ajout de `hide_id_columns.py` : script/module autonome qui cache toutes les colonnes `_id` dans la première section de chaque table via l'API Grist
- Appel de `IdColumnHider.hide_id_columns()` en fin de `process_demarche_for_grist_optimized`, uniquement si `schema_method_successful` (évite les appels API inutiles sur les syncs incrémentales sans changement de schéma)

Rejouer le script plusieurs fois ne pose pas de problème : une colonne déjà cachée est simplement ignorée.
Si le masquage échoue, l'erreur est loggée mais n'interrompt pas la synchronisation.