### PR TITLE
Détection des dossiers supprimés via l'API DN

### DIFF
--- a/deleted_dossiers_checker.py
+++ b/deleted_dossiers_checker.py
@@ -1,0 +1,134 @@
+# -*- coding: utf-8 -*-
+"""
+Détection des dossiers supprimés de Démarches Simplifiées, via le champ
+`deletedDossiers` de l'API DN. Interroge l'API directement (plus de comparaison
+par absence) et met à jour les colonnes dossiers_supprimes_DN, date_suppression
+et raison_suppression dans Grist.
+"""
+
+import requests
+
+from queries_graphql import get_deleted_dossiers
+
+COLUMN_ID = "dossiers_supprimes_DN"
+COLUMN_LABEL = "Dossiers supprimés DN"
+DATE_COLUMN_ID = "date_suppression"
+REASON_COLUMN_ID = "raison_suppression"
+
+
+def _ensure_deletion_columns(client, table_id, log, log_error):
+    """Crée les colonnes de suppression (Bool/DateTime/Text) si elles n'existent pas."""
+    url = f"{client.base_url}/docs/{client.doc_id}/tables/{table_id}/columns"
+    response = requests.get(url, headers=client.headers)
+    existing = (
+        {col["id"] for col in response.json().get("columns", [])}
+        if response.status_code == 200
+        else set()
+    )
+
+    needed = [
+        {"id": COLUMN_ID, "fields": {"label": COLUMN_LABEL, "type": "Bool"}},
+        {
+            "id": DATE_COLUMN_ID,
+            "fields": {"label": "Date de suppression", "type": "DateTime"},
+        },
+        {
+            "id": REASON_COLUMN_ID,
+            "fields": {"label": "Raison de suppression", "type": "Text"},
+        },
+    ]
+    missing = [c for c in needed if c["id"] not in existing]
+    if not missing:
+        return True
+
+    r = requests.post(url, headers=client.headers, json={"columns": missing})
+    if r.status_code == 200:
+        log(f"  Colonnes créées : {[c['id'] for c in missing]}")
+        return True
+
+    log_error(f"  Impossible de créer les colonnes : {r.status_code} - {r.text}")
+    return False
+
+
+def _mark_deleted_in_grist(
+    client, table_id, grist_dict, deleted_dossiers, log, log_error
+):
+    """PATCH en batch les records à marquer comme supprimés, avec date et raison."""
+    records = []
+    for d in deleted_dossiers:
+        num_str = str(d["number"])
+        if num_str not in grist_dict:
+            continue
+        records.append(
+            {
+                "id": grist_dict[num_str],
+                "fields": {
+                    COLUMN_ID: True,
+                    DATE_COLUMN_ID: d.get("dateSupression"),
+                    REASON_COLUMN_ID: d.get("reason"),
+                },
+            }
+        )
+
+    if not records:
+        return 0
+
+    url = f"{client.base_url}/docs/{client.doc_id}/tables/{table_id}/records"
+    response = requests.patch(url, headers=client.headers, json={"records": records})
+
+    if response.status_code == 200:
+        log(f"  {len(records)} dossiers marqués '{COLUMN_LABEL}' dans Grist.")
+        return len(records)
+
+    log_error(f"  Erreur PATCH Grist: {response.status_code} - {response.text}")
+    return 0
+
+
+def check_deleted_dossiers(
+    client, table_id, demarche_number, log, log_error, deleted_since=None
+):
+    """
+    Récupère les dossiers supprimés directement depuis l'API DN (deletedDossiers)
+    et met à jour les colonnes correspondantes dans Grist.
+
+    Args:
+        client:          Instance GristClient
+        table_id:        ID de la table dossiers
+        demarche_number: Numéro de la démarche
+        log:             Fonction de log du processeur principal
+        log_error:       Fonction de log d'erreur
+        deleted_since:   ISO8601DateTime optionnel, pour limiter aux suppressions récentes
+
+    Returns:
+        dict: {"ds_deleted_total": int, "newly_marked": int, "deleted_numbers": list[int]}
+    """
+    log("\n--- Vérification des dossiers supprimés (API DN) ---")
+    log(
+        f"  deleted_since utilisé : {deleted_since or '(aucun — récupération complète)'}"
+    )
+
+    if not _ensure_deletion_columns(client, table_id, log, log_error):
+        return {}
+
+    deleted_dossiers = get_deleted_dossiers(
+        demarche_number, deleted_since=deleted_since
+    )
+    log(f"  Dossiers supprimés côté DN : {len(deleted_dossiers)}")
+
+    if not deleted_dossiers:
+        log("  ✅ Aucun dossier supprimé détecté.")
+        log("--- Fin vérification dossiers supprimés ---\n")
+        return {"ds_deleted_total": 0, "newly_marked": 0}
+
+    grist_dict = client.get_existing_dossier_numbers(table_id)
+    newly_marked = _mark_deleted_in_grist(
+        client, table_id, grist_dict, deleted_dossiers, log, log_error
+    )
+
+    log("--- Fin vérification dossiers supprimés ---\n")
+
+    return {
+        "ds_deleted_total": len(deleted_dossiers),
+        "newly_marked": newly_marked,
+        "deleted_numbers": sorted(d["number"] for d in deleted_dossiers),
+    }

--- a/grist_processor_working_all.py
+++ b/grist_processor_working_all.py
@@ -3236,7 +3236,7 @@ def process_demarche_for_grist_optimized(
                 current_table_ids = set()
                 _flatten_table_ids(table_ids, current_table_ids)
                 hider = IdColumnHider(client.base_url, client.api_key, client.doc_id)
-                hider.hide_id_columns()
+                hider.hide_id_columns(table_ids=current_table_ids)
             except Exception as e:
                 log_error(f"Erreur lors du masquage des colonnes _id: {e}")
 

--- a/grist_processor_working_all.py
+++ b/grist_processor_working_all.py
@@ -2534,7 +2534,7 @@ def process_demarche_for_grist_optimized(
             try:
                 from deleted_dossiers_checker import check_deleted_dossiers
 
-                check_deleted_dossiers(
+                deletion_result = check_deleted_dossiers(
                     client=client,
                     table_id=table_ids["dossier_table_id"],
                     demarche_number=demarche_number,
@@ -2542,7 +2542,8 @@ def process_demarche_for_grist_optimized(
                     log_error=log_error,
                     deleted_since=deleted_since_cursor,
                 )
-
+                nb_deleted = (deletion_result or {}).get("newly_marked", 0)
+                log(f"Nombre de dossiers marqués supprimés dans Grist : {nb_deleted}")
             except Exception as e:
                 log_error(f"Erreur vérification dossiers supprimés : {e}")
 
@@ -3217,7 +3218,7 @@ def process_demarche_for_grist_optimized(
         try:
             from deleted_dossiers_checker import check_deleted_dossiers
 
-            check_deleted_dossiers(
+            deletion_result = check_deleted_dossiers(
                 client=client,
                 table_id=table_ids["dossier_table_id"],
                 demarche_number=demarche_number,
@@ -3225,6 +3226,8 @@ def process_demarche_for_grist_optimized(
                 log_error=log_error,
                 deleted_since=deleted_since_cursor,
             )
+            nb_deleted = (deletion_result or {}).get("newly_marked", 0)
+            log(f"Nombre de dossiers marqués supprimés dans Grist : {nb_deleted}")
 
         except Exception as e:
             log_error(f"Erreur vérification dossiers supprimés : {e}")

--- a/grist_processor_working_all.py
+++ b/grist_processor_working_all.py
@@ -3233,6 +3233,8 @@ def process_demarche_for_grist_optimized(
             try:
                 from hide_id_columns import IdColumnHider
 
+                current_table_ids = set()
+                _flatten_table_ids(table_ids, current_table_ids)
                 hider = IdColumnHider(client.base_url, client.api_key, client.doc_id)
                 hider.hide_id_columns()
             except Exception as e:

--- a/grist_processor_working_all.py
+++ b/grist_processor_working_all.py
@@ -67,6 +67,18 @@ def print_api_timings():
     print("=" * 50 + "\n")
 
 
+def _flatten_table_ids(value, acc):
+    """Aplatit récursivement table_ids (dict/list/str imbriqués) en un set de tableId."""
+    if isinstance(value, str):
+        acc.add(value)
+    elif isinstance(value, dict):
+        for v in value.values():
+            _flatten_table_ids(v, acc)
+    elif isinstance(value, (list, tuple, set)):
+        for v in value:
+            _flatten_table_ids(v, acc)
+
+
 def get_optimized_schema(demarche_number):
     """
     Récupération optimisée du schéma avec fallback automatique.

--- a/grist_processor_working_all.py
+++ b/grist_processor_working_all.py
@@ -220,7 +220,6 @@ def detect_column_types_from_multiple_dossiers(dossiers_data, problematic_ids=No
         {"id": "groupe_instructeur_id", "type": "Text"},
         {"id": "groupe_instructeur_number", "type": "Int"},
         {"id": "groupe_instructeur_label", "type": "Text"},
-        {"id": "supprime_par_usager", "type": "Bool"},
         {"id": "date_suppression", "type": "DateTime"},
         {"id": "label_names", "type": "Text"},
         {"id": "labels_json", "type": "Text"},
@@ -2332,6 +2331,12 @@ def process_demarche_for_grist_optimized(
                 updated_since_cursor, tz=timezone.utc
             ).strftime("%Y-%m-%dT%H:%M:%SZ")
         sync_meta_grist_id = sync_meta.get("grist_id") if sync_meta else None
+        deleted_since_cursor = (
+            None
+            if force_full_sync
+            else (sync_meta.get("deleted_since_cursor") if sync_meta else None)
+        )
+
         if force_full_sync:
             log("force_full_sync activé → sync complète forcée")
         elif updated_since_cursor:
@@ -2505,6 +2510,7 @@ def process_demarche_for_grist_optimized(
                     {
                         "last_sync_at": sync_end_time,
                         "updated_since_cursor": sync_start_time,
+                        "deleted_since_cursor": sync_start_time,
                         "last_sync_status": "success",
                         "last_sync_duration": round(elapsed_time, 1),
                         "force_full_sync": False,
@@ -2512,6 +2518,22 @@ def process_demarche_for_grist_optimized(
                 )
             except Exception as e:
                 log_error(f"Erreur sauvegarde Sync_metadata: {e}")
+
+            try:
+                from deleted_dossiers_checker import check_deleted_dossiers
+
+                check_deleted_dossiers(
+                    client=client,
+                    table_id=table_ids["dossier_table_id"],
+                    demarche_number=demarche_number,
+                    log=log,
+                    log_error=log_error,
+                    deleted_since=deleted_since_cursor,
+                )
+
+            except Exception as e:
+                log_error(f"Erreur vérification dossiers supprimés : {e}")
+
             return True
 
         # Organiser les dossiers en lots
@@ -3170,6 +3192,7 @@ def process_demarche_for_grist_optimized(
                 {
                     "last_sync_at": sync_end_time,
                     "updated_since_cursor": sync_start_time,
+                    "deleted_since_cursor": sync_start_time,
                     "last_sync_status": "success" if total_errors == 0 else "partial",
                     "last_sync_duration": round(elapsed_time, 1),
                     "force_full_sync": False,
@@ -3178,6 +3201,21 @@ def process_demarche_for_grist_optimized(
             )
         except Exception as e:
             log_error(f"Erreur sauvegarde Sync_metadata: {e}")
+
+        try:
+            from deleted_dossiers_checker import check_deleted_dossiers
+
+            check_deleted_dossiers(
+                client=client,
+                table_id=table_ids["dossier_table_id"],
+                demarche_number=demarche_number,
+                log=log,
+                log_error=log_error,
+                deleted_since=deleted_since_cursor,
+            )
+
+        except Exception as e:
+            log_error(f"Erreur vérification dossiers supprimés : {e}")
 
         if schema_method_successful:
             try:

--- a/grist_processor_working_all.py
+++ b/grist_processor_working_all.py
@@ -16,6 +16,7 @@ from dotenv import load_dotenv
 import repetable_processor as rp
 from queries import dossier_to_flat_data, get_demarche, get_dossier
 from queries_graphql import get_demarche_dossiers_filtered
+from deleted_dossiers_checker import check_deleted_dossiers
 from queries_util import get_timings
 from schema_utils import (
     create_columns_from_schema,
@@ -2532,8 +2533,6 @@ def process_demarche_for_grist_optimized(
                 log_error(f"Erreur sauvegarde Sync_metadata: {e}")
 
             try:
-                from deleted_dossiers_checker import check_deleted_dossiers
-
                 deletion_result = check_deleted_dossiers(
                     client=client,
                     table_id=table_ids["dossier_table_id"],
@@ -3216,8 +3215,6 @@ def process_demarche_for_grist_optimized(
             log_error(f"Erreur sauvegarde Sync_metadata: {e}")
 
         try:
-            from deleted_dossiers_checker import check_deleted_dossiers
-
             deletion_result = check_deleted_dossiers(
                 client=client,
                 table_id=table_ids["dossier_table_id"],

--- a/hide_id_columns.py
+++ b/hide_id_columns.py
@@ -123,9 +123,11 @@ class IdColumnHider:
             nb_ok += 1
 
         if hidden:
-            log(f"[OK] {len(hidden)} colonne(s) cachée(s) : {', '.join(hidden)}")
+            hidden_tables = sorted({h.split(".")[0] for h in hidden})
+            log(f"[OK] {len(hidden)} colonne(s) cachée(s) sur : {', '.join(hidden_tables)}")
         if skipped:
-            log(f"[SKIP] {len(skipped)} colonne(s) déjà cachée(s) ou absente(s)")
+            skipped_tables = sorted({s.split(".")[0] for s in skipped})
+            log(f"[SKIP] {len(skipped)} colonne(s) sur : {', '.join(skipped_tables)}")
 
         return nb_ok, nb_skip
 

--- a/hide_id_columns.py
+++ b/hide_id_columns.py
@@ -59,10 +59,13 @@ class IdColumnHider:
             )
         resp.raise_for_status()
 
-    def hide_id_columns(self, suffix="_id"):
+    def hide_id_columns(self, suffix="_id", table_ids=None):
         """
         Cache dans la première section de chaque table toutes les colonnes
         dont le colId se termine par `suffix`. Retourne (nb_ok, nb_skip).
+
+        table_ids : ensemble optionnel de tableId (ex: {"Demarche_149930_dossiers", ...})
+        à traiter. Si None, traite tout le document.
         """
         tables = {
             r["id"]: r["fields"]["tableId"]
@@ -97,6 +100,10 @@ class IdColumnHider:
 
             table_ref = col["fields"].get("parentId")
             table_name = tables.get(table_ref, f"tableRef={table_ref}")
+
+            if table_ids is not None and table_name not in table_ids:
+                continue
+
             col_ref = col["id"]
             section_id = first_section.get(table_ref)
 

--- a/hide_id_columns.py
+++ b/hide_id_columns.py
@@ -108,20 +108,17 @@ class IdColumnHider:
             section_id = first_section.get(table_ref)
 
             if section_id is None:
-                log(f"[SKIP] {table_name}.{col_id} — aucune section trouvée", 2)
                 skipped.append(f"{table_name}.{col_id}")
                 nb_skip += 1
                 continue
 
             field_id = field_index.get((section_id, col_ref))
             if field_id is None:
-                log(f"[SKIP] {table_name}.{col_id} — déjà cachée ou absente", 2)
                 skipped.append(f"{table_name}.{col_id}")
                 nb_skip += 1
                 continue
 
             self._hide_field(field_id)
-            log(f"[OK]   {table_name}.{col_id} cachée (section {section_id})", 2)
             hidden.append(f"{table_name}.{col_id}")
             nb_ok += 1
 

--- a/queries_graphql.py
+++ b/queries_graphql.py
@@ -7,8 +7,8 @@ from dotenv import load_dotenv
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-from utils.constants import DEMARCHES_API_URL
 from queries_util import timed
+from utils.constants import DEMARCHES_API_URL
 
 load_dotenv()
 API_TOKEN = os.getenv("DEMARCHES_API_TOKEN") or ""
@@ -1146,109 +1146,12 @@ def get_demarche_dossiers_filtered(
     return filtered_dossiers
 
 
-# ================================================
-# SCRIPT DE TEST SIMPLE qui fonctionne
-# ================================================
-
-
-def test_working_filter():
-    """
-    Test avec SEULEMENT les paramètres qui fonctionnent
-    """
-    print("=== TEST avec seulement createdSince (qui fonctionne) ===")
-
-    query = """
-    query testWorkingFilter($demarcheNumber: Int!, $createdSince: ISO8601DateTime) {
-        demarche(number: $demarcheNumber) {
-            id
-            title
-            dossiers(first: 5, createdSince: $createdSince) {
-                pageInfo {
-                    hasNextPage
-                    endCursor
-                }
-                nodes {
-                    id
-                    number
-                    dateDepot
-                    state
-                    groupeInstructeur {
-                        id
-                        number
-                        label
-                    }
-                }
-            }
-        }
-    }
-    """
-
-    variables = {"demarcheNumber": 70018, "createdSince": "2025-06-15T00:00:00Z"}
-
-    headers = {
-        "Authorization": f"Bearer {API_TOKEN}",
-        "Content-Type": "application/json",
-    }
-
-    session = get_session_with_retries()  # ✅ AJOUTE
-    response = session.post(
-        API_URL, json={"query": query, "variables": variables}, headers=headers
-    )
-
-    if response.status_code == 200:
-        result = response.json()
-        if "errors" in result:
-            print(f"Erreurs: {result['errors']}")
-        else:
-            dossiers = result["data"]["demarche"]["dossiers"]["nodes"]
-            print(f"[OK]SUCCESS! {len(dossiers)} dossiers après 2025-06-15")
-
-            for dossier in dossiers:
-                groupe = dossier["groupeInstructeur"]
-                print(
-                    f"{dossier['number']}: {dossier['dateDepot'][:10]} - Groupe {groupe['number']}"
-                )
-    else:
-        print(f"Erreur HTTP: {response.status_code}")
-
-
-if __name__ == "__main__":
-    test_working_filter()
-
-
-# ================================================
-# RÉCAPITULATIF des paramètres API réels
-# ================================================
-
-"""
-[FILTRAGE] PARAMÈTRES GRAPHQL RÉELLEMENT SUPPORTÉS (testé) :
-
-[OK]CÔTÉ SERVEUR :
-- createdSince: ISO8601DateTime  # Date de début uniquement
-
-❌ NON SUPPORTÉS côté serveur :
-- createdUntil                   # Date de fin
-- groupeInstructeurNumber        # Groupe instructeur
-- states                         # Statuts des dossiers
-
-SOLUTION HYBRIDE :
-1. Filtrer par date de début côté serveur (gain majeur)
-2. Filtrer le reste côté client sur le résultat réduit
-
-🎯 PERFORMANCE :
-Au lieu de récupérer 6450 dossiers puis tout filtrer,
-on récupère ~200 dossiers (après 2025-06-15) puis on filtre
-seulement ceux-là par groupe et statut.
-
-GAIN ESTIMÉ : 30x plus rapide !
-"""
-
-
 def get_demarche_dossiers(demarche_number: int):
     """
-    Récupère uniquement la liste des dossiers d'une démarche, avec gestion de la pagination.
-    Récupère tous les dossiers même s'il y en a plus de 100.
-    ANCIENNE VERSION - utilisez get_demarche_dossiers_filtered pour de meilleures performances.
+    Récupère tous les dossiers d'une démarche, sans filtre, avec pagination
+    (délègue à get_demarche_dossiers_filtered sans arguments).
+    Utilisée pour l'échantillonnage lors de la détection du schéma et comme
+    fallback "récupération classique" quand aucun filtre optimisé n'est actif.
     """
     return get_demarche_dossiers_filtered(demarche_number)
 
@@ -1276,3 +1179,93 @@ def get_dossier_geojson(dossier_number: int) -> Dict[str, Any]:
     response.raise_for_status()
 
     return response.json()
+
+
+def get_deleted_dossiers(
+    demarche_number: int, deleted_since: str = None
+) -> List[Dict[str, Any]]:
+    """
+    Récupère les dossiers supprimés d'une démarche, en fusionnant :
+    - deletedDossiers : suppression confirmée par DN
+    - pendingDeletedDossiers : suppression en attente (période de grâce), mais déjà
+    invisible pour les instructeurs dans DN — traité ici comme supprimé.
+    Pagination complète sur les deux connexions.
+    deleted_since (ISO8601) limite deletedDossiers aux suppressions récentes.
+    """
+    if not API_TOKEN:
+        raise ValueError("Le token d'API n'est pas configuré.")
+
+    if not deleted_since:
+        deleted_since = None
+
+    headers = {
+        "Authorization": f"Bearer {API_TOKEN}",
+        "Content-Type": "application/json",
+    }
+    session = get_session_with_retries()
+    all_deleted = []
+
+    # --- deletedDossiers (suppression confirmée) ---
+    query_deleted = """
+    query getDeletedDossiers($demarcheNumber: Int!, $first: Int, $after: String, $since: ISO8601DateTime) {
+        demarche(number: $demarcheNumber) {
+            deletedDossiers(first: $first, after: $after, deletedSince: $since) {
+                pageInfo { hasNextPage endCursor }
+                nodes { number dateSupression state reason }
+            }
+        }
+    }
+    """
+    cursor = None
+    has_next_page = True
+    while has_next_page:
+        variables = {
+            "demarcheNumber": demarche_number,
+            "first": 100,
+            "after": cursor,
+            "since": deleted_since,
+        }
+        response = session.post(
+            API_URL,
+            json={"query": query_deleted, "variables": variables},
+            headers=headers,
+        )
+        response.raise_for_status()
+        result = response.json()
+        if "errors" in result:
+            raise Exception(f"GraphQL errors: {result['errors']}")
+        connection = result["data"]["demarche"]["deletedDossiers"]
+        all_deleted.extend(connection["nodes"])
+        has_next_page = connection["pageInfo"]["hasNextPage"]
+        cursor = connection["pageInfo"]["endCursor"]
+
+    # --- pendingDeletedDossiers (en attente, mais déjà invisible pour les instructeurs) ---
+    query_pending = """
+    query getPendingDeletedDossiers($demarcheNumber: Int!, $first: Int, $after: String) {
+        demarche(number: $demarcheNumber) {
+            pendingDeletedDossiers(first: $first, after: $after) {
+                pageInfo { hasNextPage endCursor }
+                nodes { number dateSupression state reason }
+            }
+        }
+    }
+    """
+    cursor = None
+    has_next_page = True
+    while has_next_page:
+        variables = {"demarcheNumber": demarche_number, "first": 100, "after": cursor}
+        response = session.post(
+            API_URL,
+            json={"query": query_pending, "variables": variables},
+            headers=headers,
+        )
+        response.raise_for_status()
+        result = response.json()
+        if "errors" in result:
+            raise Exception(f"GraphQL errors: {result['errors']}")
+        connection = result["data"]["demarche"]["pendingDeletedDossiers"]
+        all_deleted.extend(connection["nodes"])
+        has_next_page = connection["pageInfo"]["hasNextPage"]
+        cursor = connection["pageInfo"]["endCursor"]
+
+    return all_deleted

--- a/schema_utils.py
+++ b/schema_utils.py
@@ -505,7 +505,6 @@ def create_columns_from_schema(demarche_schema, demarche_number=None):
         {"id": "date_derniere_modification", "type": "DateTime"},
         {"id": "date_expiration", "type": "DateTime"},
         {"id": "date_traitement", "type": "DateTime"},
-        {"id": "supprime_par_usager", "type": "Bool"},
         {"id": "date_suppression", "type": "DateTime"},
         {"id": "date_derniere_correction_en_attente", "type": "DateTime"},
         {"id": "date_derniere_modification_champs", "type": "DateTime"},

--- a/static/js/sync.js
+++ b/static/js/sync.js
@@ -229,7 +229,7 @@ const updateTaskProgress = (task) => {
     if (task.status === 'completed' && !hasSignificantErrors) {
       // TODO use showSyncBanner or derivated
       if (task.sync_reason === 'already_up_to_date') {
-         const nbDeleted = (task.result && task.result.deleted_dossiers_count) || 0
+        const nbDeleted = (task.result && task.result.deleted_dossiers_count) || 0
         const deletedLine = nbDeleted > 0
           ? `<p>${nbDeleted} dossier(s) supprimé(s) dans DN (mis à jour dans Grist)</p>`
           : ''

--- a/static/js/sync.js
+++ b/static/js/sync.js
@@ -229,9 +229,14 @@ const updateTaskProgress = (task) => {
     if (task.status === 'completed' && !hasSignificantErrors) {
       // TODO use showSyncBanner or derivated
       if (task.sync_reason === 'already_up_to_date') {
+         const nbDeleted = (task.result && task.result.deleted_dossiers_count) || 0
+        const deletedLine = nbDeleted > 0
+          ? `<p>${nbDeleted} dossier(s) supprimé(s) dans DN (mis à jour dans Grist)</p>`
+          : ''
         if (resultContentManual) resultContentManual.innerHTML = `<div class="fr-alert fr-alert--info">
           <h3 class="fr-alert__title">Grist déjà à jour</h3>
           <p>Aucun dossier nouveau ou modifié depuis la dernière synchronisation.</p>
+          ${deletedLine}
           <p>${task.message}</p>
         </div>`
         showNotification('Grist déjà à jour', 'info')

--- a/static/js/sync.js
+++ b/static/js/sync.js
@@ -10,26 +10,25 @@ const showSyncBanner = (
   successCount,
   errorCount,
   timestamp,
-  syncType
+  syncType,
+  nbDeleted = 0
 ) => {
   const container = document.getElementById(containerId)
   const subContainer = container.querySelector('.sync_banner_template')
   if (!container || !subContainer) throw new Error('Missing container(s)')
-
   const isSuccess = status === 'success'
   const isWarning = status === 'warning'
   const alertClass = isSuccess ? 'fr-alert--success' : isWarning ? 'fr-alert--warning' : 'fr-alert--error'
   const typeLabel = syncType === 'auto' ? '(automatique)' : '(déclenchée manuellement)'
   const message = isSuccess ? 'Synchronisation terminée avec succès' : 'Synchronisation terminée avec erreur(s)'
-  const title = typeLabel ? `${message} ${typeLabel}`: message
-  const count = `${successCount} dossiers traités avec succès, ${errorCount} en échec`
+  const title = typeLabel ? `${message} ${typeLabel}`: message
+  const deletedPart = nbDeleted > 0 ? `, ${nbDeleted} dossier(s) supprimé(s) dans DN (mis à jour dans Grist)` : ''
+  const count = `${successCount} dossiers traités avec succès, ${errorCount} en échec${deletedPart}`
   const date = timestamp ? new Date(timestamp).toLocaleString('fr-FR') : new Date().toLocaleString('fr-FR')
-
   subContainer.querySelector('.fr-alert').classList.add(alertClass)
   subContainer.querySelector('h3').innerText = title
   subContainer.querySelector('.sync-banner-count').innerText = count
   subContainer.querySelector('.sync-banner-date').innerText = date
-
   container.style.display = 'block'
 }
 
@@ -241,7 +240,8 @@ const updateTaskProgress = (task) => {
         </div>`
         showNotification('Grist déjà à jour', 'info')
       } else {
-        showSyncBanner('result_content_manual', 'success', successCount, errorCount)
+        const nbDeleted = (task.result && task.result.deleted_dossiers_count) || 0
+        showSyncBanner('result_content_manual', 'success', successCount, errorCount, undefined, undefined, nbDeleted)
         showNotification('Synchronisation terminée avec succès!', 'success')
       }
     } else if (

--- a/sync/sync_manager.py
+++ b/sync/sync_manager.py
@@ -267,7 +267,7 @@ class SyncManager:
                 {
                     "status": "completed" if is_success else "error",
                     "progress": 100,
-                    "message": "Tâche terminée avec succès"
+                    "message": result.get("message", "Tâche terminée avec succès")
                     if is_success
                     else result.get("message", "Erreur"),
                     "result": result,

--- a/sync/sync_manager.py
+++ b/sync/sync_manager.py
@@ -267,7 +267,7 @@ class SyncManager:
                 {
                     "status": "completed" if is_success else "error",
                     "progress": 100,
-                    "message": result.get("message", "Tâche terminée avec succès")
+                    "message": "Tâche terminée avec succès"
                     if is_success
                     else result.get("message", "Erreur"),
                     "result": result,

--- a/sync/sync_result_parser.py
+++ b/sync/sync_result_parser.py
@@ -55,6 +55,7 @@ def parse_output(output_lines: list[str]) -> dict:
     total_processed = 0
     errors_list = []
 
+    nb_deleted = 0
     # Parser la sortie pour extraire les statistiques
     for line in output_lines:
         # Essayer de parser succès
@@ -76,6 +77,17 @@ def parse_output(output_lines: list[str]) -> dict:
             except (ValueError, IndexError):
                 pass
 
+        # Essayer de parser le nombre de dossiers supprimés côté DN
+        if "Nombre de dossiers marqués supprimés dans Grist :" in line:
+            try:
+                nb_deleted = int(
+                    line.split("Nombre de dossiers marqués supprimés dans Grist :")[
+                        -1
+                    ].strip()
+                )
+            except (ValueError, IndexError):
+                pass
+
     # Calculer total si pas déjà extrait
     if total_processed == 0:
         total_processed = success_count + error_count
@@ -90,16 +102,23 @@ def parse_output(output_lines: list[str]) -> dict:
         )
     )
 
+    message = (
+        f"Synchronisation terminée: {success_count}/{total_processed} dossiers synchronisés"
+        if error_count == 0
+        else f"Synchronisation terminée avec {error_count} erreurs sur {total_processed} dossiers"
+    )
+    if nb_deleted > 0:
+        message += f" — {nb_deleted} dossier(s) supprimé(s) dans DN (mis à jour dans Grist)"
+
     return {
         "success": error_count == 0,
         "sync_reason": "already_up_to_date" if already_up_to_date else "synced",
-        "message": f"Synchronisation terminée: {success_count}/{total_processed} dossiers synchronisés"
-        if error_count == 0
-        else f"Synchronisation terminée avec {error_count} erreurs sur {total_processed} dossiers",
+        "message": message,
         "dossier_count": total_processed,
         "success_count": success_count,
         "error_count": error_count,
         "total_processed": total_processed,
+        "deleted_dossiers_count": nb_deleted,
         "errors": errors_list,
         "timestamp": datetime.now(timezone.utc).isoformat(),
     }


### PR DESCRIPTION
## Détection des dossiers supprimés via l'API DN

Remplace la détection par absence (comparer les dossiers Grist à ceux renvoyés
par la synchro, valable uniquement en full sync) par une lecture directe des
champs `deletedDossiers` / `pendingDeletedDossiers` de l'API.

### Pourquoi
- La détection par absence ne fonctionnait qu'en synchro complète.
- Elle ne donnait ni la date exacte de suppression, ni la raison.
- Les dossiers en attente de suppression (déjà invisibles pour les
  instructeurs) n'étaient pas pris en compte.

### Ce qui change
- Nouvelle fonction `get_deleted_dossiers()` dans `queries_graphql.py`.
- `deleted_dossiers_checker.py` interroge l'API directement.
- Deux nouvelles colonnes Grist alimentées : `date_suppression` (réutilisée)
  et `raison_suppression` (`user_request` / `manager_request` / `expired`).
- La vérification tourne désormais à chaque synchro, y compris incrémentale,
  grâce à un cursor `deleted_since_cursor` dans `Sync_metadata` (évite de
  re-télécharger tout l'historique des suppressions à chaque fois).

### Retour utilisateur (rectifié)
- Un premier essai faisait passer le message technique du parser
  (`Synchronisation terminée: X/Y...`) à la place de "Tâche terminée avec
  succès" — corrigé : le texte de fin de tâche reste inchangé.
- Le nombre de dossiers supprimés dans DN (mis à jour dans Grist) s'affiche
  désormais comme ligne dédiée dans la bannière "Grist déjà à jour", entre
  le message habituel et "Tâche terminée avec succès".

### Masquage des colonnes `_id` (`hide_id_columns.py`)
- `IdColumnHider.hide_id_columns()` scannait tout le document Grist à chaque
  synchro, quelle que soit la démarche en cours — les logs affichaient donc
  des colonnes d'autres démarches sans rapport avec la synchro en cours.
  Ajout d'un paramètre `table_ids` optionnel pour restreindre le traitement
  aux tables de la démarche synchronisée (`grist_processor_working_all.py`
  aplatit `table_ids`, quelle que soit sa forme, via une fonction utilitaire
  `_flatten_table_ids`).
- Logs compactés : une ligne de résumé par catégorie (`[OK] N colonne(s)
  cachée(s) sur : ...` / `[SKIP] N colonne(s) sur : ...`, listant les tables
  concernées) au lieu d'une ligne par colonne.

### Nettoyage annexe
- `queries_graphql.py` : suppression du script de test mort
  (`test_working_filter` + son `if __name__ == "__main__":`), du bloc de
  commentaires "RÉCAPITULATIF" laissé sous forme de chaîne flottante, et des
  imports inutilisés (`json`, `time`, `Optional`).
- Retrait de la colonne `supprime_par_usager` (schéma + code) : elle n'était
  jamais alimentée en pratique (bug de mapping préexistant), et sa
  réparation aurait nécessité un full sync périodique pour rester à jour —
  jugé disproportionné pour un signal aussi rare (cf. mécanisme de double
  suppression usager/instructeur sur les dossiers "terminés"). L'information
  reste captée in fine via `deletedDossiers`/`pendingDeletedDossiers` une
  fois la suppression effective des deux côtés.