### PR TITLE
feat: ajout colonne correction_instructeur à la table dossiers

### DIFF
--- a/grist_processor_working_all.py
+++ b/grist_processor_working_all.py
@@ -238,6 +238,7 @@ def detect_column_types_from_multiple_dossiers(dossiers_data, problematic_ids=No
         {"id": "labels_json", "type": "Text"},
         {"id": "suivi_par", "type": "Text"},
         {"id": "date_accuse_lecture", "type": "DateTime"},
+        {"id": "correction_instructeur", "type": "Text"},
         {"id": "date_derniere_correction_en_attente", "type": "DateTime"},
     ]
 

--- a/queries_extract.py
+++ b/queries_extract.py
@@ -895,6 +895,13 @@ def dossier_to_flat_data(
         ),
     }
 
+    # Email de l'instructeur ayant demandé la dernière correction
+    correction_instructeur = None
+    for traitement in dossier_data.get("traitements", []):
+        if traitement.get("event") == "depose_correction_instructeur":
+            correction_instructeur = traitement.get("emailAgentTraitant")
+    flat_data["correction_instructeur"] = correction_instructeur
+
     # Ajouter les informations sur les labels (étiquettes)
     if "labels" in dossier_data and dossier_data["labels"]:
         # Création d'une liste des noms de labels

--- a/queries_graphql.py
+++ b/queries_graphql.py
@@ -384,6 +384,7 @@ fragment DossierFragment on Dossier {
     }
     traitements @include(if: $includeTraitements) {
         state
+        event
         emailAgentTraitant
         dateTraitement
         motivation
@@ -558,6 +559,7 @@ fragment DossierFragment on Dossier {
     }
     traitements @include(if: $includeTraitements) {
         state
+        event
         emailAgentTraitant
         dateTraitement
         motivation

--- a/schema_utils.py
+++ b/schema_utils.py
@@ -514,6 +514,7 @@ def create_columns_from_schema(demarche_schema, demarche_number=None):
         {"id": "labels_json", "type": "Text"},
         {"id": "suivi_par", "type": "Text"},
         {"id": "date_accuse_lecture", "type": "DateTime"},
+        {"id": "correction_instructeur", "type": "Text"},
     ]
 
     # Colonnes de base pour la table des champs


### PR DESCRIPTION
## Contexte

On veut savoir quel instructeur a modifié un dossier.

## Ce qui change

- La requête GraphQL récupère maintenant le champ `event` de chaque traitement, 
  ce qui permet de repérer précisément l'événement `depose_correction_instructeur`.
- Lors de l'extraction d'un dossier, on récupère l'email de l'instructeur associé 
  à ce traitement (s'il y en a plusieurs, on garde le plus récent).
- Une nouvelle colonne `correction_instructeur` est ajoutée à la table des dossiers.

## Compatibilité sync incrémentale

Un traitement de type `depose_correction_instructeur` met à jour la date de 
dernière modification du dossier, donc il sera bien repris lors des prochains 
syncs incrémentaux (pas besoin de force_full_sync).

## Fichiers modifiés

- `queries_graphql.py`
- `queries_extract.py`
- `schema_utils.py`
- `grist_processor_working_all.py`