### PR TITLE
execute tâches démarches sans dossier modifié

### DIFF
--- a/grist_processor_working_all.py
+++ b/grist_processor_working_all.py
@@ -14,6 +14,10 @@ import requests
 from dotenv import load_dotenv
 
 import repetable_processor as rp
+from deleted_dossiers_checker import check_deleted_dossiers
+from hide_id_columns import IdColumnHider
+from instructeurs_checker import sync_instructeurs
+from labels_checker import sync_labels_for_demarche
 from queries import dossier_to_flat_data, get_dossier
 from queries_graphql import get_demarche_dossiers_filtered
 from queries_util import get_timings
@@ -1633,17 +1637,18 @@ def run_demarche_level_tasks(
     """
     Opérations de niveau démarche, indépendantes des dossiers effectivement traités.
 
-    Doit être appelée aussi bien sur le chemin nominal que sur la sortie anticipée
-    « aucun dossier modifié » : poser une étiquette, ajouter un instructeur ou
-    supprimer un dossier ne fait remonter aucun dossier via `updatedSince`.
+    À appeler depuis les deux `return` de `process_demarche_for_grist_optimized` :
+    celui de fin de fonction et celui du cas `total_dossiers == 0`. Poser une
+    étiquette, ajouter un instructeur ou supprimer un dossier ne met à jour aucun
+    dossier au sens d'`updatedSince` : sans le second appel, ces changements ne
+    remonteraient dans Grist que si un dossier avait bougé par ailleurs.
 
-    Chaque tâche est isolée : un échec n'empêche pas les suivantes.
+    Chaque tâche est isolée dans son propre try/except : un échec n'empêche pas
+    les suivantes.
     """
     # 1. Instructeurs (niveau démarche, à chaque sync)
     if table_ids.get("instructeurs"):
         try:
-            from instructeurs_checker import sync_instructeurs
-
             sync_instructeurs(
                 client, table_ids["instructeurs"], demarche_number, log, log_error
             )
@@ -1655,8 +1660,6 @@ def run_demarche_level_tasks(
     #    par le chemin principal — ce passage serait redondant.
     if updated_since_cursor and not force_full_sync:
         try:
-            from labels_checker import sync_labels_for_demarche
-
             sync_labels_for_demarche(
                 client, table_ids["dossier_table_id"], demarche_number, log, log_error
             )
@@ -1667,8 +1670,6 @@ def run_demarche_level_tasks(
 
     # 3. Dossiers supprimés (API DN, curseur dédié)
     try:
-        from deleted_dossiers_checker import check_deleted_dossiers
-
         deletion_result = check_deleted_dossiers(
             client=client,
             table_id=table_ids["dossier_table_id"],
@@ -1685,8 +1686,6 @@ def run_demarche_level_tasks(
     # 4. Masquage des colonnes _id (toujours en dernier)
     if schema_method_successful:
         try:
-            from hide_id_columns import IdColumnHider
-
             current_table_ids = set()
             _flatten_table_ids(table_ids, current_table_ids)
             hider = IdColumnHider(client.base_url, client.api_key, client.doc_id)

--- a/grist_processor_working_all.py
+++ b/grist_processor_working_all.py
@@ -14,7 +14,6 @@ import requests
 from dotenv import load_dotenv
 
 import repetable_processor as rp
-from deleted_dossiers_checker import check_deleted_dossiers
 from queries import dossier_to_flat_data, get_dossier
 from queries_graphql import get_demarche_dossiers_filtered
 from queries_util import get_timings
@@ -1622,6 +1621,84 @@ class GristClient:
         return success
 
 
+def run_demarche_level_tasks(
+    client,
+    table_ids,
+    demarche_number,
+    updated_since_cursor=None,
+    force_full_sync=False,
+    deleted_since_cursor=None,
+    schema_method_successful=False,
+):
+    """
+    Opérations de niveau démarche, indépendantes des dossiers effectivement traités.
+
+    Doit être appelée aussi bien sur le chemin nominal que sur la sortie anticipée
+    « aucun dossier modifié » : poser une étiquette, ajouter un instructeur ou
+    supprimer un dossier ne fait remonter aucun dossier via `updatedSince`.
+
+    Chaque tâche est isolée : un échec n'empêche pas les suivantes.
+    """
+    # 1. Instructeurs (niveau démarche, à chaque sync)
+    if table_ids.get("instructeurs"):
+        try:
+            from instructeurs_checker import sync_instructeurs
+
+            sync_instructeurs(
+                client, table_ids["instructeurs"], demarche_number, log, log_error
+            )
+        except Exception as e:
+            log_error(f"Erreur synchronisation instructeurs: {e}")
+
+    # 2. Labels : uniquement en sync incrémentale.
+    #    En sync complète, tous les dossiers sont refetchés et leurs labels réécrits
+    #    par le chemin principal — ce passage serait redondant.
+    if updated_since_cursor and not force_full_sync:
+        try:
+            from labels_checker import sync_labels_for_demarche
+
+            sync_labels_for_demarche(
+                client, table_ids["dossier_table_id"], demarche_number, log, log_error
+            )
+        except Exception as e:
+            log_error(f"Erreur rafraîchissement des labels: {e}")
+    else:
+        log("Sync complète — rafraîchissement des labels ignoré (déjà à jour).")
+
+    # 3. Dossiers supprimés (API DN, curseur dédié)
+    try:
+        from deleted_dossiers_checker import check_deleted_dossiers
+
+        deletion_result = check_deleted_dossiers(
+            client=client,
+            table_id=table_ids["dossier_table_id"],
+            demarche_number=demarche_number,
+            log=log,
+            log_error=log_error,
+            deleted_since=deleted_since_cursor,
+        )
+        nb_deleted = (deletion_result or {}).get("newly_marked", 0)
+        log(f"Nombre de dossiers marqués supprimés dans Grist : {nb_deleted}")
+    except Exception as e:
+        log_error(f"Erreur vérification dossiers supprimés : {e}")
+
+    # 4. Masquage des colonnes _id (toujours en dernier)
+    if schema_method_successful:
+        try:
+            from hide_id_columns import IdColumnHider
+
+            current_table_ids = set()
+            _flatten_table_ids(table_ids, current_table_ids)
+            hider = IdColumnHider(client.base_url, client.api_key, client.doc_id)
+            hider.hide_id_columns(table_ids=current_table_ids)
+        except Exception as e:
+            log_error(f"Erreur lors du masquage des colonnes _id: {e}")
+
+
+# Fonction optimisée pour le traitement d'une démarche pour Grist (Possibilité d'augmenter ou de diminuer batch_size et max_workers)
+# Cette fonction est conçue pour être plus rapide et plus efficace, en utilisant le traitement par lots et le traitement parallèle.
+# Fonction optimisée complète et corrigée
+# Remplace la fonction process_demarche_for_grist_optimized dans ton fichier
 def process_demarche_for_grist_optimized(
     client,
     demarche_number,
@@ -2032,19 +2109,15 @@ def process_demarche_for_grist_optimized(
             except Exception as e:
                 log_error(f"Erreur sauvegarde Sync_metadata: {e}")
 
-            try:
-                deletion_result = check_deleted_dossiers(
-                    client=client,
-                    table_id=table_ids["dossier_table_id"],
-                    demarche_number=demarche_number,
-                    log=log,
-                    log_error=log_error,
-                    deleted_since=deleted_since_cursor,
-                )
-                nb_deleted = (deletion_result or {}).get("newly_marked", 0)
-                log(f"Nombre de dossiers marqués supprimés dans Grist : {nb_deleted}")
-            except Exception as e:
-                log_error(f"Erreur vérification dossiers supprimés : {e}")
+            run_demarche_level_tasks(
+                client,
+                table_ids,
+                demarche_number,
+                updated_since_cursor=updated_since_cursor,
+                force_full_sync=force_full_sync,
+                deleted_since_cursor=deleted_since_cursor,
+                schema_method_successful=schema_method_successful,
+            )
 
             return True
 
@@ -2213,11 +2286,6 @@ def process_demarche_for_grist_optimized(
                 table_ids.get("annotations")
             )
         cache_demandeurs = client.get_existing_dossier_numbers(table_ids["demandeurs"])
-        cache_instructeurs = {}
-        if table_ids.get("instructeurs"):
-            cache_instructeurs = client.get_existing_dossier_numbers(
-                table_ids["instructeurs"]
-            )
         log(f"Cache global préchargé en {time.time() - start_cache:.1f}s")
 
         # Construire les sets de dossiers à skipper par table
@@ -2225,130 +2293,6 @@ def process_demarche_for_grist_optimized(
         skip_champs = set()
         skip_annotations = set()
 
-        # Synchroniser les instructeurs UNE SEULE FOIS (niveau démarche)
-        if table_ids.get("instructeurs"):
-            log(f"  Récupération des instructeurs de la démarche {demarche_number}...")
-
-            from queries_extract import extract_instructeurs_from_demarche
-
-            instructeurs_records = extract_instructeurs_from_demarche(demarche_number)
-
-            if instructeurs_records:
-                log(f"  {len(instructeurs_records)} instructeur(s) trouvé(s)")
-
-                # Récupérer les enregistrements existants
-                url = f"{client.base_url}/docs/{client.doc_id}/tables/{table_ids['instructeurs']}/records"
-                response = requests.get(url, headers=client.headers)
-
-                existing_records = []
-                if response.status_code == 200:
-                    existing_records = response.json().get("records", [])
-
-                #  UPSERT INTELLIGENT - Créer un mapping par instructeur_id
-                existing_map = {}
-                for record in existing_records:
-                    fields = record.get("fields", {})
-                    instructeur_id = fields.get("instructeur_id")
-                    groupe_id = fields.get("groupe_instructeur_id")
-                    if instructeur_id and groupe_id:
-                        composite_key = f"{instructeur_id}_{groupe_id}"
-                        existing_map[composite_key] = {
-                            "grist_id": record.get("id"),
-                            "fields": fields,
-                        }
-
-                # Créer un mapping des nouveaux instructeurs
-                new_map = {
-                    f"{r['instructeur_id']}_{r['groupe_instructeur_id']}": r
-                    for r in instructeurs_records
-                }
-
-                # Identifier les opérations nécessaires
-                to_delete = []
-                to_create = []
-                to_update = []
-
-                # Qui supprimer ?
-                for composite_key, existing_data in existing_map.items():
-                    if composite_key not in new_map:
-                        to_delete.append(existing_data["grist_id"])
-
-                # Qui créer ou mettre à jour ?
-                for composite_key, new_data in new_map.items():
-                    if composite_key in existing_map:
-                        existing_fields = existing_map[composite_key]["fields"]
-                        needs_update = False
-                        for key in [
-                            "groupe_instructeur_id",
-                            "groupe_instructeur_number",
-                            "groupe_instructeur_label",
-                            "instructeur_email",
-                        ]:
-                            if existing_fields.get(key) != new_data.get(key):
-                                needs_update = True
-                                break
-                        if needs_update:
-                            to_update.append(
-                                {
-                                    "id": existing_map[composite_key]["grist_id"],
-                                    "fields": new_data,
-                                }
-                            )
-                    else:
-                        to_create.append(new_data)
-
-                # Appliquer les changements
-                operations_count = 0
-
-                if to_delete:
-                    delete_response = requests.post(
-                        f"{url}/delete", headers=client.headers, json=to_delete
-                    )
-                    if delete_response.status_code in [200, 201]:
-                        log(f"  🗑️  {len(to_delete)} instructeur(s) supprimé(s)")
-                        operations_count += len(to_delete)
-                    else:
-                        log_error(
-                            f"   Erreur suppression instructeurs: {delete_response.text}"
-                        )
-
-                if to_update:
-                    update_response = requests.patch(
-                        url, headers=client.headers, json={"records": to_update}
-                    )
-                    if update_response.status_code in [200, 201]:
-                        log(f"   {len(to_update)} instructeur(s) mis à jour")
-                        operations_count += len(to_update)
-                    else:
-                        log_error(
-                            f"   Erreur mise à jour instructeurs: {update_response.text}"
-                        )
-
-                if to_create:
-                    create_payload = {"records": [{"fields": r} for r in to_create]}
-                    create_response = requests.post(
-                        url, headers=client.headers, json=create_payload
-                    )
-                    if create_response.status_code in [200, 201]:
-                        log(f"   {len(to_create)} instructeur(s) créé(s)")
-                        operations_count += len(to_create)
-                    else:
-                        log_error(
-                            f"   Erreur création instructeurs: {create_response.text}"
-                        )
-
-                if operations_count == 0:
-                    log("   Table instructeurs à jour (aucun changement)")
-                else:
-                    log(
-                        f"   Table instructeurs synchronisée ({operations_count} opération(s))"
-                    )
-
-            else:
-                log("   Aucun instructeur trouvé pour cette démarche")
-            log(
-                f"[TIMING] Instructeurs synchronisés en {time.time() - start_cache:.1f}s"
-            )
         for batch_idx, batch in enumerate(dossier_batches):
             log(
                 f"Traitement du lot {batch_idx + 1}/{batch_count} ({len(batch)} dossiers)..."
@@ -2714,32 +2658,15 @@ def process_demarche_for_grist_optimized(
         except Exception as e:
             log_error(f"Erreur sauvegarde Sync_metadata: {e}")
 
-        try:
-            deletion_result = check_deleted_dossiers(
-                client=client,
-                table_id=table_ids["dossier_table_id"],
-                demarche_number=demarche_number,
-                log=log,
-                log_error=log_error,
-                deleted_since=deleted_since_cursor,
-            )
-            nb_deleted = (deletion_result or {}).get("newly_marked", 0)
-            log(f"Nombre de dossiers marqués supprimés dans Grist : {nb_deleted}")
-
-        except Exception as e:
-            log_error(f"Erreur vérification dossiers supprimés : {e}")
-
-        if schema_method_successful:
-            try:
-                from hide_id_columns import IdColumnHider
-
-                current_table_ids = set()
-                _flatten_table_ids(table_ids, current_table_ids)
-                hider = IdColumnHider(client.base_url, client.api_key, client.doc_id)
-                hider.hide_id_columns(table_ids=current_table_ids)
-            except Exception as e:
-                log_error(f"Erreur lors du masquage des colonnes _id: {e}")
-
+        run_demarche_level_tasks(
+            client,
+            table_ids,
+            demarche_number,
+            updated_since_cursor=updated_since_cursor,
+            force_full_sync=force_full_sync,
+            deleted_since_cursor=deleted_since_cursor,
+            schema_method_successful=schema_method_successful,
+        )
         return total_success > 0 or schema_method_successful
 
     except Exception as e:

--- a/grist_processor_working_all.py
+++ b/grist_processor_working_all.py
@@ -12,12 +12,12 @@ from zoneinfo import ZoneInfo
 
 import requests
 from dotenv import load_dotenv
+from sync.tasks.instructeurs import sync_instructeurs
+from sync.tasks.labels import sync_labels_for_demarche
 
 import repetable_processor as rp
 from deleted_dossiers_checker import check_deleted_dossiers
 from hide_id_columns import IdColumnHider
-from instructeurs_checker import sync_instructeurs
-from labels_checker import sync_labels_for_demarche
 from queries import dossier_to_flat_data, get_dossier
 from queries_graphql import get_demarche_dossiers_filtered
 from queries_util import get_timings

--- a/instructeurs_checker.py
+++ b/instructeurs_checker.py
@@ -1,0 +1,207 @@
+# -*- coding: utf-8 -*-
+"""
+Synchronisation de la table Instructeurs (niveau démarche).
+
+Récupère les instructeurs de la démarche via l'API DN (groupeInstructeurs) et
+met la table Grist à jour par upsert sur la clé composite
+`instructeur_id` + `groupe_instructeur_id` : créations, mises à jour, suppressions.
+
+Utilisation autonome :
+    python instructeurs_checker.py
+
+Variables d'environnement requises :
+    GRIST_BASE_URL, GRIST_API_KEY, GRIST_DOC_ID, DEMARCHE_NUMBER
+"""
+
+import os
+import sys
+import time
+
+import requests
+
+from queries_extract import extract_instructeurs_from_demarche
+
+# Champs comparés pour décider si un enregistrement existant doit être mis à jour
+COMPARED_FIELDS = [
+    "groupe_instructeur_id",
+    "groupe_instructeur_number",
+    "groupe_instructeur_label",
+    "instructeur_email",
+]
+
+
+def _composite_key(instructeur_id, groupe_instructeur_id):
+    """Clé unique d'un instructeur au sein d'un groupe."""
+    return f"{instructeur_id}_{groupe_instructeur_id}"
+
+
+def _fetch_existing_records(client, table_id):
+    """Récupère les enregistrements actuels de la table instructeurs."""
+    url = f"{client.base_url}/docs/{client.doc_id}/tables/{table_id}/records"
+    response = requests.get(url, headers=client.headers)
+
+    if response.status_code != 200:
+        return []
+
+    return response.json().get("records", [])
+
+
+def _build_existing_map(existing_records):
+    """Indexe les enregistrements Grist existants par clé composite."""
+    existing_map = {}
+    for record in existing_records:
+        fields = record.get("fields", {})
+        instructeur_id = fields.get("instructeur_id")
+        groupe_id = fields.get("groupe_instructeur_id")
+        if instructeur_id and groupe_id:
+            existing_map[_composite_key(instructeur_id, groupe_id)] = {
+                "grist_id": record.get("id"),
+                "fields": fields,
+            }
+    return existing_map
+
+
+def _compute_operations(existing_map, new_map):
+    """Détermine les enregistrements à supprimer, mettre à jour et créer."""
+    to_delete = [
+        data["grist_id"] for key, data in existing_map.items() if key not in new_map
+    ]
+
+    to_update = []
+    to_create = []
+
+    for key, new_data in new_map.items():
+        if key not in existing_map:
+            to_create.append(new_data)
+            continue
+
+        existing_fields = existing_map[key]["fields"]
+        if any(existing_fields.get(f) != new_data.get(f) for f in COMPARED_FIELDS):
+            to_update.append({"id": existing_map[key]["grist_id"], "fields": new_data})
+
+    return to_delete, to_update, to_create
+
+
+def _apply_operations(
+    client, table_id, to_delete, to_update, to_create, log, log_error
+):
+    """Applique les suppressions, mises à jour et créations dans Grist."""
+    url = f"{client.base_url}/docs/{client.doc_id}/tables/{table_id}/records"
+    operations_count = 0
+
+    if to_delete:
+        response = requests.post(
+            f"{url}/delete", headers=client.headers, json=to_delete
+        )
+        if response.status_code in [200, 201]:
+            log(f"  🗑️  {len(to_delete)} instructeur(s) supprimé(s)")
+            operations_count += len(to_delete)
+        else:
+            log_error(f"  Erreur suppression instructeurs: {response.text}")
+
+    if to_update:
+        response = requests.patch(
+            url, headers=client.headers, json={"records": to_update}
+        )
+        if response.status_code in [200, 201]:
+            log(f"  {len(to_update)} instructeur(s) mis à jour")
+            operations_count += len(to_update)
+        else:
+            log_error(f"  Erreur mise à jour instructeurs: {response.text}")
+
+    if to_create:
+        payload = {"records": [{"fields": r} for r in to_create]}
+        response = requests.post(url, headers=client.headers, json=payload)
+        if response.status_code in [200, 201]:
+            log(f"  {len(to_create)} instructeur(s) créé(s)")
+            operations_count += len(to_create)
+        else:
+            log_error(f"  Erreur création instructeurs: {response.text}")
+
+    return operations_count
+
+
+def sync_instructeurs(client, table_id, demarche_number, log=print, log_error=print):
+    """
+    Synchronise la table Instructeurs d'une démarche dans Grist.
+
+    Args:
+        client:          Instance GristClient
+        table_id:        ID de la table instructeurs
+        demarche_number: Numéro de la démarche
+        log:             Fonction de log du processeur principal
+        log_error:       Fonction de log d'erreur
+
+    Returns:
+        dict: {"total": int, "created": int, "updated": int, "deleted": int}
+    """
+    start_time = time.time()
+    log(f"  Récupération des instructeurs de la démarche {demarche_number}...")
+
+    instructeurs_records = extract_instructeurs_from_demarche(demarche_number)
+
+    if not instructeurs_records:
+        log("  Aucun instructeur trouvé pour cette démarche")
+        return {"total": 0, "created": 0, "updated": 0, "deleted": 0}
+
+    log(f"  {len(instructeurs_records)} instructeur(s) trouvé(s)")
+
+    existing_map = _build_existing_map(_fetch_existing_records(client, table_id))
+    new_map = {
+        _composite_key(r["instructeur_id"], r["groupe_instructeur_id"]): r
+        for r in instructeurs_records
+    }
+
+    to_delete, to_update, to_create = _compute_operations(existing_map, new_map)
+
+    operations_count = _apply_operations(
+        client, table_id, to_delete, to_update, to_create, log, log_error
+    )
+
+    if operations_count == 0:
+        log("  Table instructeurs à jour (aucun changement)")
+    else:
+        log(f"  Table instructeurs synchronisée ({operations_count} opération(s))")
+
+    log(f"[TIMING] Instructeurs synchronisés en {time.time() - start_time:.1f}s")
+
+    return {
+        "total": len(instructeurs_records),
+        "created": len(to_create),
+        "updated": len(to_update),
+        "deleted": len(to_delete),
+    }
+
+
+def main():
+    from dotenv import load_dotenv
+
+    from grist_processor_working_all import GristClient
+
+    load_dotenv(override=True)
+
+    grist_base_url = os.getenv("GRIST_BASE_URL")
+    grist_api_key = os.getenv("GRIST_API_KEY")
+    grist_doc_id = os.getenv("GRIST_DOC_ID")
+    demarche_number = os.getenv("DEMARCHE_NUMBER")
+
+    if not all([grist_base_url, grist_api_key, grist_doc_id, demarche_number]):
+        print(
+            "Configuration incomplète : GRIST_BASE_URL, GRIST_API_KEY, "
+            "GRIST_DOC_ID et DEMARCHE_NUMBER sont requis dans le fichier .env"
+        )
+        return 1
+
+    demarche_number = int(demarche_number)
+    table_id = os.getenv(
+        "TABLE_INSTRUCTEURS", f"Demarche_{demarche_number}_instructeurs"
+    )
+
+    client = GristClient(grist_base_url, grist_api_key, grist_doc_id)
+    sync_instructeurs(client, table_id, demarche_number)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/instructeurs_checker.py
+++ b/instructeurs_checker.py
@@ -36,12 +36,21 @@ def _composite_key(instructeur_id, groupe_instructeur_id):
 
 
 def _fetch_existing_records(client, table_id):
-    """Récupère les enregistrements actuels de la table instructeurs."""
+    """Récupère les enregistrements actuels de la table instructeurs.
+
+    Raises:
+        RuntimeError: si Grist ne répond pas correctement. Confondre un échec de
+            lecture avec une table vide provoquerait la recréation de tous les
+            instructeurs, donc des doublons.
+    """
     url = f"{client.base_url}/docs/{client.doc_id}/tables/{table_id}/records"
     response = requests.get(url, headers=client.headers)
 
     if response.status_code != 200:
-        return []
+        raise RuntimeError(
+            f"Lecture de la table {table_id} impossible : "
+            f"{response.status_code} - {response.text}"
+        )
 
     return response.json().get("records", [])
 
@@ -61,8 +70,9 @@ def _build_existing_map(existing_records):
     return existing_map
 
 
-def _compute_operations(existing_map, new_map):
-    """Détermine les enregistrements à supprimer, mettre à jour et créer."""
+def _diff_records(existing_map, new_map):
+    """Compare l'état Grist et l'état DN, et retourne les enregistrements
+    à supprimer, à mettre à jour et à créer."""
     to_delete = [
         data["grist_id"] for key, data in existing_map.items() if key not in new_map
     ]
@@ -82,7 +92,7 @@ def _compute_operations(existing_map, new_map):
     return to_delete, to_update, to_create
 
 
-def _apply_operations(
+def _apply_records_diff(
     client, table_id, to_delete, to_update, to_create, log, log_error
 ):
     """Applique les suppressions, mises à jour et créations dans Grist."""
@@ -136,13 +146,14 @@ def sync_instructeurs(client, table_id, demarche_number, log=print, log_error=pr
         dict: {"total": int, "created": int, "updated": int, "deleted": int}
     """
     start_time = time.time()
+    result = {"total": 0, "created": 0, "updated": 0, "deleted": 0}
     log(f"  Récupération des instructeurs de la démarche {demarche_number}...")
 
     instructeurs_records = extract_instructeurs_from_demarche(demarche_number)
 
     if not instructeurs_records:
         log("  Aucun instructeur trouvé pour cette démarche")
-        return {"total": 0, "created": 0, "updated": 0, "deleted": 0}
+        return result
 
     log(f"  {len(instructeurs_records)} instructeur(s) trouvé(s)")
 
@@ -152,9 +163,9 @@ def sync_instructeurs(client, table_id, demarche_number, log=print, log_error=pr
         for r in instructeurs_records
     }
 
-    to_delete, to_update, to_create = _compute_operations(existing_map, new_map)
+    to_delete, to_update, to_create = _diff_records(existing_map, new_map)
 
-    operations_count = _apply_operations(
+    operations_count = _apply_records_diff(
         client, table_id, to_delete, to_update, to_create, log, log_error
     )
 
@@ -165,12 +176,16 @@ def sync_instructeurs(client, table_id, demarche_number, log=print, log_error=pr
 
     log(f"[TIMING] Instructeurs synchronisés en {time.time() - start_time:.1f}s")
 
-    return {
-        "total": len(instructeurs_records),
-        "created": len(to_create),
-        "updated": len(to_update),
-        "deleted": len(to_delete),
-    }
+    result.update(
+        {
+            "total": len(instructeurs_records),
+            "created": len(to_create),
+            "updated": len(to_update),
+            "deleted": len(to_delete),
+        }
+    )
+
+    return result
 
 
 def main():

--- a/labels_checker.py
+++ b/labels_checker.py
@@ -1,0 +1,204 @@
+# -*- coding: utf-8 -*-
+"""
+Rafraîchissement des labels (étiquettes) des dossiers dans Grist.
+
+L'ajout ou le retrait d'un label ne met pas à jour `dateDerniereModification` côté DN :
+un dossier dont seuls les labels ont changé n'est donc jamais remonté par le filtre
+`updatedSince`, et ses colonnes `label_names` / `labels_json` restent périmées.
+
+Ce script interroge tous les dossiers de la démarche avec une requête minimaliste
+(number + labels) et met à jour les seules lignes dont les labels ont changé.
+
+Utilisation autonome :
+    python labels_checker.py
+
+Variables d'environnement requises :
+    GRIST_BASE_URL, GRIST_API_KEY, GRIST_DOC_ID, DEMARCHE_NUMBER
+"""
+
+import json
+import os
+import sys
+import time
+
+import requests
+
+from queries_graphql import get_demarche_dossiers_labels_only
+
+BATCH_SIZE = 500
+
+
+def _build_label_fields(labels):
+    """Construit label_names / labels_json à partir des labels d'un dossier."""
+    if not labels:
+        return {"label_names": "", "labels_json": ""}
+
+    label_names = [label.get("name", "") for label in labels if label.get("name")]
+
+    labels_with_colors = [
+        {
+            "id": label.get("id", ""),
+            "name": label.get("name", ""),
+            "color": label.get("color", ""),
+        }
+        for label in labels
+        if label.get("name") and label.get("color")
+    ]
+
+    return {
+        "label_names": ", ".join(label_names) if label_names else "",
+        "labels_json": (
+            json.dumps(labels_with_colors, ensure_ascii=False)
+            if labels_with_colors
+            else ""
+        ),
+    }
+
+
+def _fetch_existing_labels(client, table_id, log_error):
+    """
+    Récupère l'état actuel des labels dans Grist.
+
+    Returns:
+        dict: {str(dossier_number): {"grist_id": int, "label_names": str, "labels_json": str}}
+    """
+    url = f"{client.base_url}/docs/{client.doc_id}/tables/{table_id}/records"
+    response = requests.get(url, headers=client.headers)
+
+    if response.status_code != 200:
+        log_error(
+            f"  Erreur récupération des dossiers Grist: "
+            f"{response.status_code} - {response.text}"
+        )
+        return {}
+
+    existing = {}
+    for record in response.json().get("records", []):
+        fields = record.get("fields", {})
+        dossier_num = fields.get("dossier_number") or fields.get("number")
+        if not dossier_num:
+            continue
+        existing[str(dossier_num)] = {
+            "grist_id": record.get("id"),
+            "label_names": fields.get("label_names") or "",
+            "labels_json": fields.get("labels_json") or "",
+        }
+
+    return existing
+
+
+def _patch_records(client, table_id, records, log, log_error):
+    """PATCH les enregistrements par lots. Retourne le nombre de lignes mises à jour."""
+    url = f"{client.base_url}/docs/{client.doc_id}/tables/{table_id}/records"
+    updated = 0
+
+    for i in range(0, len(records), BATCH_SIZE):
+        batch = records[i : i + BATCH_SIZE]
+        response = requests.patch(url, headers=client.headers, json={"records": batch})
+        if response.status_code in [200, 201]:
+            updated += len(batch)
+        else:
+            log_error(
+                f"  Erreur PATCH labels ({len(batch)} lignes): "
+                f"{response.status_code} - {response.text}"
+            )
+
+    if updated:
+        log(f"  {updated} dossier(s) mis à jour (labels)")
+
+    return updated
+
+
+def sync_labels_for_demarche(
+    client, table_id, demarche_number, log=print, log_error=print
+):
+    """
+    Rafraîchit les colonnes label_names / labels_json des dossiers présents dans Grist.
+
+    Args:
+        client:          Instance GristClient
+        table_id:        ID de la table dossiers
+        demarche_number: Numéro de la démarche
+        log:             Fonction de log du processeur principal
+        log_error:       Fonction de log d'erreur
+
+    Returns:
+        dict: {"checked": int, "updated": int, "missing_in_grist": int}
+    """
+    start_time = time.time()
+    log("\n--- Rafraîchissement des labels ---")
+
+    existing = _fetch_existing_labels(client, table_id, log_error)
+    if not existing:
+        log("  Aucun dossier dans Grist — rien à rafraîchir.")
+        log("--- Fin rafraîchissement des labels ---\n")
+        return {"checked": 0, "updated": 0, "missing_in_grist": 0}
+
+    dossiers = get_demarche_dossiers_labels_only(demarche_number)
+    log(f"  {len(dossiers)} dossier(s) interrogé(s) côté DN")
+
+    to_update = []
+    missing_in_grist = 0
+
+    for dossier in dossiers:
+        num_str = str(dossier.get("number"))
+        current = existing.get(num_str)
+        if not current:
+            missing_in_grist += 1
+            continue
+
+        fields = _build_label_fields(dossier.get("labels"))
+        if (
+            fields["label_names"] == current["label_names"]
+            and fields["labels_json"] == current["labels_json"]
+        ):
+            continue
+
+        to_update.append({"id": current["grist_id"], "fields": fields})
+
+    if not to_update:
+        log("  Labels déjà à jour (aucun changement)")
+        updated = 0
+    else:
+        updated = _patch_records(client, table_id, to_update, log, log_error)
+
+    log(f"[TIMING] Labels rafraîchis en {time.time() - start_time:.1f}s")
+    log("--- Fin rafraîchissement des labels ---\n")
+
+    return {
+        "checked": len(dossiers),
+        "updated": updated,
+        "missing_in_grist": missing_in_grist,
+    }
+
+
+def main():
+    from dotenv import load_dotenv
+
+    from grist_processor_working_all import GristClient
+
+    load_dotenv(override=True)
+
+    grist_base_url = os.getenv("GRIST_BASE_URL")
+    grist_api_key = os.getenv("GRIST_API_KEY")
+    grist_doc_id = os.getenv("GRIST_DOC_ID")
+    demarche_number = os.getenv("DEMARCHE_NUMBER")
+
+    if not all([grist_base_url, grist_api_key, grist_doc_id, demarche_number]):
+        print(
+            "Configuration incomplète : GRIST_BASE_URL, GRIST_API_KEY, "
+            "GRIST_DOC_ID et DEMARCHE_NUMBER sont requis dans le fichier .env"
+        )
+        return 1
+
+    demarche_number = int(demarche_number)
+    table_id = os.getenv("TABLE_DOSSIERS", f"Demarche_{demarche_number}_dossiers")
+
+    client = GristClient(grist_base_url, grist_api_key, grist_doc_id)
+    sync_labels_for_demarche(client, table_id, demarche_number)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/labels_checker.py
+++ b/labels_checker.py
@@ -1,11 +1,6 @@
 # -*- coding: utf-8 -*-
 """
 Rafraîchissement des labels (étiquettes) des dossiers dans Grist.
-
-L'ajout ou le retrait d'un label ne met pas à jour `dateDerniereModification` côté DN :
-un dossier dont seuls les labels ont changé n'est donc jamais remonté par le filtre
-`updatedSince`, et ses colonnes `label_names` / `labels_json` restent périmées.
-
 Ce script interroge tous les dossiers de la démarche avec une requête minimaliste
 (number + labels) et met à jour les seules lignes dont les labels ont changé.
 
@@ -55,7 +50,7 @@ def _build_label_fields(labels):
     }
 
 
-def _fetch_existing_labels(client, table_id, log_error):
+def _fetch_existing_labels(client, table_id):
     """
     Récupère l'état actuel des labels dans Grist.
 
@@ -66,11 +61,10 @@ def _fetch_existing_labels(client, table_id, log_error):
     response = requests.get(url, headers=client.headers)
 
     if response.status_code != 200:
-        log_error(
-            f"  Erreur récupération des dossiers Grist: "
+        raise RuntimeError(
+            f"Lecture de la table {table_id} impossible : "
             f"{response.status_code} - {response.text}"
         )
-        return {}
 
     existing = {}
     for record in response.json().get("records", []):
@@ -126,13 +120,14 @@ def sync_labels_for_demarche(
         dict: {"checked": int, "updated": int, "missing_in_grist": int}
     """
     start_time = time.time()
+    result = {"checked": 0, "updated": 0, "missing_in_grist": 0}
     log("\n--- Rafraîchissement des labels ---")
 
-    existing = _fetch_existing_labels(client, table_id, log_error)
+    existing = _fetch_existing_labels(client, table_id)
     if not existing:
         log("  Aucun dossier dans Grist — rien à rafraîchir.")
         log("--- Fin rafraîchissement des labels ---\n")
-        return {"checked": 0, "updated": 0, "missing_in_grist": 0}
+        return result
 
     dossiers = get_demarche_dossiers_labels_only(demarche_number)
     log(f"  {len(dossiers)} dossier(s) interrogé(s) côté DN")
@@ -158,18 +153,21 @@ def sync_labels_for_demarche(
 
     if not to_update:
         log("  Labels déjà à jour (aucun changement)")
-        updated = 0
-    else:
-        updated = _patch_records(client, table_id, to_update, log, log_error)
+
+    updated = _patch_records(client, table_id, to_update, log, log_error)
 
     log(f"[TIMING] Labels rafraîchis en {time.time() - start_time:.1f}s")
     log("--- Fin rafraîchissement des labels ---\n")
 
-    return {
-        "checked": len(dossiers),
-        "updated": updated,
-        "missing_in_grist": missing_in_grist,
-    }
+    result.update(
+        {
+            "checked": len(dossiers),
+            "updated": updated,
+            "missing_in_grist": missing_in_grist,
+        }
+    )
+
+    return result
 
 
 def main():

--- a/queries_graphql.py
+++ b/queries_graphql.py
@@ -1206,7 +1206,12 @@ def get_demarche_dossiers_labels_only(demarche_number: int) -> List[Dict[str, An
     cursor = None
     page_num = 0
 
-    while True:
+    dossiers = []
+    cursor = None
+    page_num = 0
+    has_next_page = True
+
+    while has_next_page:
         page_num += 1
         response = session.post(
             API_URL,
@@ -1223,17 +1228,10 @@ def get_demarche_dossiers_labels_only(demarche_number: int) -> List[Dict[str, An
             messages = [e.get("message", "Unknown error") for e in result["errors"]]
             raise Exception(f"GraphQL errors: {', '.join(messages)}")
 
-        demarche_data = (result.get("data") or {}).get("demarche") or {}
-        connection = demarche_data.get("dossiers") or {}
-        if not connection:
-            break
-
-        dossiers.extend(connection.get("nodes", []))
-
-        page_info = connection.get("pageInfo", {})
-        if not page_info.get("hasNextPage"):
-            break
-        cursor = page_info.get("endCursor")
+        connection = result["data"]["demarche"]["dossiers"]
+        dossiers.extend(connection["nodes"])
+        has_next_page = connection["pageInfo"]["hasNextPage"]
+        cursor = connection["pageInfo"]["endCursor"]
 
     print(f"[LABELS] {len(dossiers)} dossiers récupérés en {page_num} page(s)")
 

--- a/queries_graphql.py
+++ b/queries_graphql.py
@@ -1161,6 +1161,85 @@ def get_demarche_dossiers(demarche_number: int):
     return get_demarche_dossiers_filtered(demarche_number)
 
 
+def get_demarche_dossiers_labels_only(demarche_number: int) -> List[Dict[str, Any]]:
+    """
+    Récupère uniquement le numéro et les labels de TOUS les dossiers d'une démarche.
+
+    Requête volontairement minimaliste (number + labels) : elle sert au rafraîchissement
+    des labels, car l'ajout ou le retrait d'un label ne met pas à jour
+    `dateDerniereModification` et échappe donc au filtre `updatedSince`.
+
+    Returns:
+        list[dict]: [{"number": int, "labels": [{"id", "name", "color"}, ...]}, ...]
+    """
+    if not API_TOKEN:
+        raise ValueError("Le token d'API n'est pas configuré.")
+
+    headers = {
+        "Authorization": f"Bearer {API_TOKEN}",
+        "Content-Type": "application/json",
+    }
+    session = get_session_with_retries()
+
+    query = """
+    query getDemarcheLabels($demarcheNumber: Int!, $after: String) {
+        demarche(number: $demarcheNumber) {
+            dossiers(first: 100, after: $after) {
+                pageInfo {
+                    hasNextPage
+                    endCursor
+                }
+                nodes {
+                    number
+                    labels {
+                        id
+                        name
+                        color
+                    }
+                }
+            }
+        }
+    }
+    """
+
+    dossiers = []
+    cursor = None
+    page_num = 0
+
+    while True:
+        page_num += 1
+        response = session.post(
+            API_URL,
+            json={
+                "query": query,
+                "variables": {"demarcheNumber": demarche_number, "after": cursor},
+            },
+            headers=headers,
+        )
+        response.raise_for_status()
+        result = response.json()
+
+        if "errors" in result:
+            messages = [e.get("message", "Unknown error") for e in result["errors"]]
+            raise Exception(f"GraphQL errors: {', '.join(messages)}")
+
+        demarche_data = (result.get("data") or {}).get("demarche") or {}
+        connection = demarche_data.get("dossiers") or {}
+        if not connection:
+            break
+
+        dossiers.extend(connection.get("nodes", []))
+
+        page_info = connection.get("pageInfo", {})
+        if not page_info.get("hasNextPage"):
+            break
+        cursor = page_info.get("endCursor")
+
+    print(f"[LABELS] {len(dossiers)} dossiers récupérés en {page_num} page(s)")
+
+    return dossiers
+
+
 def get_dossier_geojson(dossier_number: int) -> Dict[str, Any]:
     """
     Récupère les données géométriques d'un dossier au format GeoJSON.

--- a/sync/README.md
+++ b/sync/README.md
@@ -1,3 +1,8 @@
 # Synchronisation
 
 Rassemble les fonctionnalités de synchronisation.
+
+## tasks/
+
+Opérations de niveau démarche exécutées pendant une synchronisation, également
+lançables en autonome depuis la racine : `python -m sync.tasks.<module>`.

--- a/sync/tasks/README.md
+++ b/sync/tasks/README.md
@@ -1,0 +1,9 @@
+# Tâches de niveau démarche
+
+Ce dossier rassemble les opérations de synchronisation liées à la démarche dans
+son ensemble, indépendamment des dossiers effectivement traités (ex. instructeurs,
+labels).
+
+Chaque tâche est isolée : un échec n'empêche pas le déroulement des autres, et
+elle est lançable en autonome depuis la racine du projet
+(`python -m sync.tasks.<module>`).

--- a/sync/tasks/instructeurs.py
+++ b/sync/tasks/instructeurs.py
@@ -6,8 +6,8 @@ Récupère les instructeurs de la démarche via l'API DN (groupeInstructeurs) et
 met la table Grist à jour par upsert sur la clé composite
 `instructeur_id` + `groupe_instructeur_id` : créations, mises à jour, suppressions.
 
-Utilisation autonome :
-    python instructeurs_checker.py
+Utilisation autonome (depuis la racine du projet) :
+    python -m sync.tasks.instructeurs
 
 Variables d'environnement requises :
     GRIST_BASE_URL, GRIST_API_KEY, GRIST_DOC_ID, DEMARCHE_NUMBER

--- a/sync/tasks/labels.py
+++ b/sync/tasks/labels.py
@@ -4,8 +4,8 @@ Rafraîchissement des labels (étiquettes) des dossiers dans Grist.
 Ce script interroge tous les dossiers de la démarche avec une requête minimaliste
 (number + labels) et met à jour les seules lignes dont les labels ont changé.
 
-Utilisation autonome :
-    python labels_checker.py
+Utilisation autonome (depuis la racine du projet) :
+    python -m sync.tasks.labels
 
 Variables d'environnement requises :
     GRIST_BASE_URL, GRIST_API_KEY, GRIST_DOC_ID, DEMARCHE_NUMBER

--- a/tests/python/unit/sync/tasks/test_instructeurs.py
+++ b/tests/python/unit/sync/tasks/test_instructeurs.py
@@ -1,0 +1,311 @@
+"""
+Tests unitaires pour la tâche de synchronisation des instructeurs
+
+Ces tests couvrent :
+- La construction de la clé composite instructeur / groupe
+- L'indexation des enregistrements Grist existants
+- Le calcul des créations, mises à jour et suppressions
+- La lecture de la table Grist et son comportement en erreur
+- L'orchestration complète de sync_instructeurs
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sync.tasks.instructeurs import (
+    _apply_records_diff,
+    _build_existing_map,
+    _composite_key,
+    _diff_records,
+    _fetch_existing_records,
+    sync_instructeurs,
+)
+
+
+def create_mock_client():
+    """Crée un mock de GristClient avec les attributs utilisés par la tâche"""
+    client = MagicMock()
+    client.base_url = "https://grist.test/api"
+    client.doc_id = "doc123"
+    client.headers = {"Authorization": "Bearer test"}
+    return client
+
+
+def create_mock_response(status_code=200, json_data=None, text=""):
+    """Crée un mock de réponse HTTP"""
+    response = MagicMock()
+    response.status_code = status_code
+    response.json.return_value = json_data if json_data is not None else {}
+    response.text = text
+    return response
+
+
+def make_instructeur(instructeur_id="i1", groupe_id="g1", email="a@test.fr"):
+    """Crée un enregistrement instructeur tel que produit par l'API DN"""
+    return {
+        "instructeur_id": instructeur_id,
+        "instructeur_email": email,
+        "groupe_instructeur_id": groupe_id,
+        "groupe_instructeur_number": 1,
+        "groupe_instructeur_label": "Groupe 1",
+    }
+
+
+class TestCompositeKey:
+    """Tests unitaires pour la fonction _composite_key"""
+
+    def test_composite_key_format(self):
+        """Test que la clé combine instructeur et groupe"""
+        assert _composite_key("i1", "g1") == "i1_g1"
+
+    def test_composite_key_is_unique_per_groupe(self):
+        """Test qu'un même instructeur dans deux groupes donne deux clés"""
+        assert _composite_key("i1", "g1") != _composite_key("i1", "g2")
+
+
+class TestBuildExistingMap:
+    """Tests unitaires pour la fonction _build_existing_map"""
+
+    def test_build_existing_map_nominal(self):
+        """Test d'indexation d'enregistrements complets"""
+        records = [
+            {
+                "id": 10,
+                "fields": {"instructeur_id": "i1", "groupe_instructeur_id": "g1"},
+            }
+        ]
+
+        result = _build_existing_map(records)
+
+        assert "i1_g1" in result
+        assert result["i1_g1"]["grist_id"] == 10
+
+    def test_build_existing_map_ignores_incomplete_records(self):
+        """Test que les enregistrements sans identifiant sont ignorés"""
+        records = [
+            {"id": 10, "fields": {"instructeur_id": "i1"}},
+            {"id": 11, "fields": {"groupe_instructeur_id": "g1"}},
+            {"id": 12, "fields": {}},
+        ]
+
+        assert _build_existing_map(records) == {}
+
+    def test_build_existing_map_empty(self):
+        """Test avec une liste vide"""
+        assert _build_existing_map([]) == {}
+
+
+class TestDiffRecords:
+    """Tests unitaires pour la fonction _diff_records"""
+
+    def test_diff_records_creation(self):
+        """Test qu'un instructeur absent de Grist est à créer"""
+        new_map = {"i1_g1": make_instructeur()}
+
+        to_delete, to_update, to_create = _diff_records({}, new_map)
+
+        assert to_delete == []
+        assert to_update == []
+        assert len(to_create) == 1
+
+    def test_diff_records_deletion(self):
+        """Test qu'un instructeur absent de DN est à supprimer"""
+        existing_map = {
+            "i1_g1": {"grist_id": 10, "fields": make_instructeur()},
+        }
+
+        to_delete, to_update, to_create = _diff_records(existing_map, {})
+
+        assert to_delete == [10]
+        assert to_update == []
+        assert to_create == []
+
+    def test_diff_records_update_on_changed_field(self):
+        """Test qu'un email modifié déclenche une mise à jour"""
+        existing_map = {
+            "i1_g1": {
+                "grist_id": 10,
+                "fields": make_instructeur(email="ancien@test.fr"),
+            }
+        }
+        new_map = {"i1_g1": make_instructeur(email="nouveau@test.fr")}
+
+        to_delete, to_update, to_create = _diff_records(existing_map, new_map)
+
+        assert to_delete == []
+        assert to_create == []
+        assert len(to_update) == 1
+        assert to_update[0]["id"] == 10
+        assert to_update[0]["fields"]["instructeur_email"] == "nouveau@test.fr"
+
+    def test_diff_records_no_change(self):
+        """Test qu'un enregistrement identique ne génère aucune opération"""
+        existing_map = {"i1_g1": {"grist_id": 10, "fields": make_instructeur()}}
+        new_map = {"i1_g1": make_instructeur()}
+
+        to_delete, to_update, to_create = _diff_records(existing_map, new_map)
+
+        assert (to_delete, to_update, to_create) == ([], [], [])
+
+    def test_diff_records_ignores_untracked_fields(self):
+        """Test qu'un champ hors COMPARED_FIELDS ne déclenche pas de mise à jour"""
+        existing = make_instructeur()
+        existing["champ_non_suivi"] = "ancien"
+        new = make_instructeur()
+        new["champ_non_suivi"] = "nouveau"
+
+        _, to_update, _ = _diff_records(
+            {"i1_g1": {"grist_id": 10, "fields": existing}}, {"i1_g1": new}
+        )
+
+        assert to_update == []
+
+
+class TestFetchExistingRecords:
+    """Tests unitaires pour la fonction _fetch_existing_records"""
+
+    @patch("sync.tasks.instructeurs.requests.get")
+    def test_fetch_existing_records_nominal(self, mock_get):
+        """Test de lecture réussie de la table Grist"""
+        mock_get.return_value = create_mock_response(
+            json_data={"records": [{"id": 1, "fields": {}}]}
+        )
+
+        records = _fetch_existing_records(create_mock_client(), "Table_1")
+
+        assert len(records) == 1
+
+    @patch("sync.tasks.instructeurs.requests.get")
+    def test_fetch_existing_records_raises_on_error(self, mock_get):
+        """Test qu'un échec de lecture lève une exception.
+
+        Retourner une liste vide ferait passer tous les instructeurs en
+        création et créerait des doublons dans la table.
+        """
+        mock_get.return_value = create_mock_response(
+            status_code=500, text="Internal Server Error"
+        )
+
+        with pytest.raises(RuntimeError):
+            _fetch_existing_records(create_mock_client(), "Table_1")
+
+
+class TestApplyRecordsDiff:
+    """Tests unitaires pour la fonction _apply_records_diff"""
+
+    @patch("sync.tasks.instructeurs.requests.post")
+    @patch("sync.tasks.instructeurs.requests.patch")
+    def test_apply_records_diff_counts_operations(self, mock_patch, mock_post):
+        """Test que le nombre d'opérations appliquées est correct"""
+        mock_post.return_value = create_mock_response()
+        mock_patch.return_value = create_mock_response()
+
+        count = _apply_records_diff(
+            create_mock_client(),
+            "Table_1",
+            to_delete=[1, 2],
+            to_update=[{"id": 3, "fields": {}}],
+            to_create=[make_instructeur()],
+            log=MagicMock(),
+            log_error=MagicMock(),
+        )
+
+        assert count == 4
+
+    @patch("sync.tasks.instructeurs.requests.post")
+    def test_apply_records_diff_logs_error_on_failure(self, mock_post):
+        """Test qu'un échec Grist est logué et non compté"""
+        mock_post.return_value = create_mock_response(
+            status_code=400, text="Bad Request"
+        )
+        log_error = MagicMock()
+
+        count = _apply_records_diff(
+            create_mock_client(),
+            "Table_1",
+            to_delete=[],
+            to_update=[],
+            to_create=[make_instructeur()],
+            log=MagicMock(),
+            log_error=log_error,
+        )
+
+        assert count == 0
+        log_error.assert_called_once()
+
+    def test_apply_records_diff_no_operation(self):
+        """Test qu'aucune requête n'est envoyée sans changement"""
+        count = _apply_records_diff(
+            create_mock_client(),
+            "Table_1",
+            to_delete=[],
+            to_update=[],
+            to_create=[],
+            log=MagicMock(),
+            log_error=MagicMock(),
+        )
+
+        assert count == 0
+
+
+class TestSyncInstructeurs:
+    """Tests unitaires pour la fonction sync_instructeurs"""
+
+    @patch("sync.tasks.instructeurs.extract_instructeurs_from_demarche")
+    def test_sync_instructeurs_no_instructeur(self, mock_extract):
+        """Test qu'aucun instructeur côté DN retourne un résultat à zéro"""
+        mock_extract.return_value = []
+
+        result = sync_instructeurs(
+            create_mock_client(), "Table_1", 12345, MagicMock(), MagicMock()
+        )
+
+        assert result == {"total": 0, "created": 0, "updated": 0, "deleted": 0}
+
+    @patch("sync.tasks.instructeurs.requests.post")
+    @patch("sync.tasks.instructeurs.requests.get")
+    @patch("sync.tasks.instructeurs.extract_instructeurs_from_demarche")
+    def test_sync_instructeurs_creates_new(self, mock_extract, mock_get, mock_post):
+        """Test qu'un instructeur absent de Grist est créé"""
+        mock_extract.return_value = [make_instructeur()]
+        mock_get.return_value = create_mock_response(json_data={"records": []})
+        mock_post.return_value = create_mock_response()
+
+        result = sync_instructeurs(
+            create_mock_client(), "Table_1", 12345, MagicMock(), MagicMock()
+        )
+
+        assert result["total"] == 1
+        assert result["created"] == 1
+        assert result["updated"] == 0
+        assert result["deleted"] == 0
+
+    @patch("sync.tasks.instructeurs.requests.get")
+    @patch("sync.tasks.instructeurs.extract_instructeurs_from_demarche")
+    def test_sync_instructeurs_no_change(self, mock_extract, mock_get):
+        """Test qu'un état identique ne génère aucune opération"""
+        mock_extract.return_value = [make_instructeur()]
+        mock_get.return_value = create_mock_response(
+            json_data={"records": [{"id": 10, "fields": make_instructeur()}]}
+        )
+
+        result = sync_instructeurs(
+            create_mock_client(), "Table_1", 12345, MagicMock(), MagicMock()
+        )
+
+        assert result["created"] == 0
+        assert result["updated"] == 0
+        assert result["deleted"] == 0
+
+    @patch("sync.tasks.instructeurs.requests.get")
+    @patch("sync.tasks.instructeurs.extract_instructeurs_from_demarche")
+    def test_sync_instructeurs_propagates_read_error(self, mock_extract, mock_get):
+        """Test qu'une erreur de lecture Grist remonte à l'appelant"""
+        mock_extract.return_value = [make_instructeur()]
+        mock_get.return_value = create_mock_response(status_code=500, text="error")
+
+        with pytest.raises(RuntimeError):
+            sync_instructeurs(
+                create_mock_client(), "Table_1", 12345, MagicMock(), MagicMock()
+            )

--- a/tests/python/unit/sync/tasks/test_labels.py
+++ b/tests/python/unit/sync/tasks/test_labels.py
@@ -1,0 +1,320 @@
+"""
+Tests unitaires pour la tâche de rafraîchissement des labels
+
+Ces tests couvrent :
+- La construction des colonnes label_names et labels_json
+- La lecture de l'état actuel dans Grist et son comportement en erreur
+- L'envoi des mises à jour par lots
+- L'orchestration complète de sync_labels_for_demarche
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sync.tasks.labels import (
+    BATCH_SIZE,
+    _build_label_fields,
+    _fetch_existing_labels,
+    _patch_records,
+    sync_labels_for_demarche,
+)
+
+
+def create_mock_client():
+    """Crée un mock de GristClient avec les attributs utilisés par la tâche"""
+    client = MagicMock()
+    client.base_url = "https://grist.test/api"
+    client.doc_id = "doc123"
+    client.headers = {"Authorization": "Bearer test"}
+    return client
+
+
+def create_mock_response(status_code=200, json_data=None, text=""):
+    """Crée un mock de réponse HTTP"""
+    response = MagicMock()
+    response.status_code = status_code
+    response.json.return_value = json_data if json_data is not None else {}
+    response.text = text
+    return response
+
+
+class TestBuildLabelFields:
+    """Tests unitaires pour la fonction _build_label_fields"""
+
+    def test_build_label_fields_empty(self):
+        """Test sans label"""
+        assert _build_label_fields([]) == {"label_names": "", "labels_json": ""}
+        assert _build_label_fields(None) == {"label_names": "", "labels_json": ""}
+
+    def test_build_label_fields_nominal(self):
+        """Test avec deux labels complets"""
+        labels = [
+            {"id": "l1", "name": "Urgent", "color": "red"},
+            {"id": "l2", "name": "À relancer", "color": "blue"},
+        ]
+
+        result = _build_label_fields(labels)
+
+        assert result["label_names"] == "Urgent, À relancer"
+        assert len(json.loads(result["labels_json"])) == 2
+
+    def test_build_label_fields_label_without_color(self):
+        """Test qu'un label sans couleur est dans label_names mais pas dans labels_json.
+
+        Comportement hérité de dossier_to_flat_data, à préserver à l'identique.
+        """
+        labels = [
+            {"id": "l1", "name": "Urgent", "color": "red"},
+            {"id": "l2", "name": "Sans couleur"},
+        ]
+
+        result = _build_label_fields(labels)
+
+        assert result["label_names"] == "Urgent, Sans couleur"
+        parsed = json.loads(result["labels_json"])
+        assert len(parsed) == 1
+        assert parsed[0]["name"] == "Urgent"
+
+    def test_build_label_fields_label_without_name(self):
+        """Test qu'un label sans nom est ignoré partout"""
+        labels = [{"id": "l1", "color": "red"}]
+
+        result = _build_label_fields(labels)
+
+        assert result["label_names"] == ""
+        assert result["labels_json"] == ""
+
+    def test_build_label_fields_preserves_accents(self):
+        """Test que les accents ne sont pas échappés dans le JSON"""
+        labels = [{"id": "l1", "name": "Contrôlé", "color": "green"}]
+
+        result = _build_label_fields(labels)
+
+        assert "Contrôlé" in result["labels_json"]
+
+
+class TestFetchExistingLabels:
+    """Tests unitaires pour la fonction _fetch_existing_labels"""
+
+    @patch("sync.tasks.labels.requests.get")
+    def test_fetch_existing_labels_nominal(self, mock_get):
+        """Test d'indexation des dossiers par numéro"""
+        mock_get.return_value = create_mock_response(
+            json_data={
+                "records": [
+                    {
+                        "id": 10,
+                        "fields": {
+                            "dossier_number": 123,
+                            "label_names": "Urgent",
+                            "labels_json": "[]",
+                        },
+                    }
+                ]
+            }
+        )
+
+        result = _fetch_existing_labels(create_mock_client(), "Table_1")
+
+        assert "123" in result
+        assert result["123"]["grist_id"] == 10
+        assert result["123"]["label_names"] == "Urgent"
+
+    @patch("sync.tasks.labels.requests.get")
+    def test_fetch_existing_labels_ignores_records_without_number(self, mock_get):
+        """Test que les lignes sans numéro de dossier sont ignorées"""
+        mock_get.return_value = create_mock_response(
+            json_data={"records": [{"id": 10, "fields": {}}]}
+        )
+
+        assert _fetch_existing_labels(create_mock_client(), "Table_1") == {}
+
+    @patch("sync.tasks.labels.requests.get")
+    def test_fetch_existing_labels_normalizes_none(self, mock_get):
+        """Test que des colonnes vides sont normalisées en chaînes"""
+        mock_get.return_value = create_mock_response(
+            json_data={
+                "records": [
+                    {
+                        "id": 10,
+                        "fields": {
+                            "dossier_number": 123,
+                            "label_names": None,
+                            "labels_json": None,
+                        },
+                    }
+                ]
+            }
+        )
+
+        result = _fetch_existing_labels(create_mock_client(), "Table_1")
+
+        assert result["123"]["label_names"] == ""
+        assert result["123"]["labels_json"] == ""
+
+    @patch("sync.tasks.labels.requests.get")
+    def test_fetch_existing_labels_raises_on_error(self, mock_get):
+        """Test qu'un échec de lecture lève une exception"""
+        mock_get.return_value = create_mock_response(status_code=500, text="error")
+
+        with pytest.raises(RuntimeError):
+            _fetch_existing_labels(create_mock_client(), "Table_1")
+
+
+class TestPatchRecords:
+    """Tests unitaires pour la fonction _patch_records"""
+
+    @patch("sync.tasks.labels.requests.patch")
+    def test_patch_records_empty(self, mock_patch):
+        """Test qu'aucune requête n'est envoyée sans enregistrement"""
+        updated = _patch_records(
+            create_mock_client(), "Table_1", [], MagicMock(), MagicMock()
+        )
+
+        assert updated == 0
+        mock_patch.assert_not_called()
+
+    @patch("sync.tasks.labels.requests.patch")
+    def test_patch_records_splits_into_batches(self, mock_patch):
+        """Test que les enregistrements sont découpés en lots"""
+        mock_patch.return_value = create_mock_response()
+        records = [{"id": i, "fields": {}} for i in range(BATCH_SIZE + 1)]
+
+        updated = _patch_records(
+            create_mock_client(), "Table_1", records, MagicMock(), MagicMock()
+        )
+
+        assert updated == BATCH_SIZE + 1
+        assert mock_patch.call_count == 2
+
+    @patch("sync.tasks.labels.requests.patch")
+    def test_patch_records_logs_error_on_failure(self, mock_patch):
+        """Test qu'un lot en échec est logué et non compté"""
+        mock_patch.return_value = create_mock_response(status_code=400, text="error")
+        log_error = MagicMock()
+
+        updated = _patch_records(
+            create_mock_client(),
+            "Table_1",
+            [{"id": 1, "fields": {}}],
+            MagicMock(),
+            log_error,
+        )
+
+        assert updated == 0
+        log_error.assert_called_once()
+
+
+class TestSyncLabelsForDemarche:
+    """Tests unitaires pour la fonction sync_labels_for_demarche"""
+
+    @patch("sync.tasks.labels.requests.get")
+    def test_sync_labels_empty_grist(self, mock_get):
+        """Test qu'une table vide retourne un résultat à zéro sans appel DN"""
+        mock_get.return_value = create_mock_response(json_data={"records": []})
+
+        result = sync_labels_for_demarche(
+            create_mock_client(), "Table_1", 12345, MagicMock(), MagicMock()
+        )
+
+        assert result == {"checked": 0, "updated": 0, "missing_in_grist": 0}
+
+    @patch("sync.tasks.labels.get_demarche_dossiers_labels_only")
+    @patch("sync.tasks.labels.requests.patch")
+    @patch("sync.tasks.labels.requests.get")
+    def test_sync_labels_updates_changed_only(self, mock_get, mock_patch, mock_dn):
+        """Test que seuls les dossiers dont les labels ont changé sont patchés"""
+        mock_get.return_value = create_mock_response(
+            json_data={
+                "records": [
+                    {
+                        "id": 10,
+                        "fields": {
+                            "dossier_number": 111,
+                            "label_names": "Urgent",
+                            "labels_json": '[{"id": "l1", "name": "Urgent", '
+                            '"color": "red"}]',
+                        },
+                    },
+                    {
+                        "id": 11,
+                        "fields": {
+                            "dossier_number": 222,
+                            "label_names": "",
+                            "labels_json": "",
+                        },
+                    },
+                ]
+            }
+        )
+        mock_patch.return_value = create_mock_response()
+        mock_dn.return_value = [
+            {
+                "number": 111,
+                "labels": [{"id": "l1", "name": "Urgent", "color": "red"}],
+            },
+            {
+                "number": 222,
+                "labels": [{"id": "l2", "name": "Nouveau", "color": "blue"}],
+            },
+        ]
+
+        result = sync_labels_for_demarche(
+            create_mock_client(), "Table_1", 12345, MagicMock(), MagicMock()
+        )
+
+        assert result["checked"] == 2
+        assert result["updated"] == 1
+        assert result["missing_in_grist"] == 0
+
+        sent_records = mock_patch.call_args.kwargs["json"]["records"]
+        assert len(sent_records) == 1
+        assert sent_records[0]["id"] == 11
+
+    @patch("sync.tasks.labels.get_demarche_dossiers_labels_only")
+    @patch("sync.tasks.labels.requests.patch")
+    @patch("sync.tasks.labels.requests.get")
+    def test_sync_labels_counts_missing_in_grist(self, mock_get, mock_patch, mock_dn):
+        """Test qu'un dossier absent de Grist est compté et non patché"""
+        mock_get.return_value = create_mock_response(
+            json_data={
+                "records": [
+                    {
+                        "id": 10,
+                        "fields": {
+                            "dossier_number": 111,
+                            "label_names": "",
+                            "labels_json": "",
+                        },
+                    }
+                ]
+            }
+        )
+        mock_dn.return_value = [
+            {"number": 111, "labels": []},
+            {"number": 999, "labels": [{"id": "l1", "name": "X", "color": "red"}]},
+        ]
+
+        result = sync_labels_for_demarche(
+            create_mock_client(), "Table_1", 12345, MagicMock(), MagicMock()
+        )
+
+        assert result["checked"] == 2
+        assert result["updated"] == 0
+        assert result["missing_in_grist"] == 1
+        mock_patch.assert_not_called()
+
+    @patch("sync.tasks.labels.get_demarche_dossiers_labels_only")
+    @patch("sync.tasks.labels.requests.get")
+    def test_sync_labels_propagates_read_error(self, mock_get, mock_dn):
+        """Test qu'une erreur de lecture Grist remonte à l'appelant"""
+        mock_get.return_value = create_mock_response(status_code=500, text="error")
+
+        with pytest.raises(RuntimeError):
+            sync_labels_for_demarche(
+                create_mock_client(), "Table_1", 12345, MagicMock(), MagicMock()
+            )
+
+        mock_dn.assert_not_called()


### PR DESCRIPTION
## Problème

Ajouter un instructeur à une démarche ou poser une étiquette sur un dossier
n'était pas répercuté dans Grist lors d'une synchronisation incrémentale.

Deux causes distinctes :

1. **Labels** — l'ajout ou le retrait d'un label ne met pas à jour
   `dateDerniereModification` côté DN (confirmé par l'équipe DN). Un dossier dont
   seuls les labels ont changé n'est donc jamais remonté par le filtre
   `updatedSince`, et ses colonnes `label_names` / `labels_json` restent périmées.

2. **Instructeurs** — la synchronisation de la table Instructeurs était placée
   après la sortie anticipée « aucun dossier modifié » de
   `process_demarche_for_grist_optimized`. Or ajouter un instructeur ne modifie
   aucun dossier : la sync sortait avant d'atteindre le bloc. Le comportement
   était donc intermittent — la table n'était mise à jour que si un dossier avait
   bougé par ailleurs.

## Solution

- Extraction de la synchro instructeurs dans `instructeurs_checker.py`
  (déplacement iso-comportement, sur le modèle de `deleted_dossiers_checker.py`).
- Nouveau `labels_checker.py` : requête DN minimaliste (`number + labels`) sur tous
  les dossiers de la démarche, comparaison avec l'état Grist, PATCH des seules
  lignes réellement modifiées. Ajout de `get_demarche_dossiers_labels_only()`
  dans `queries_graphql.py`.
- Nouveau point d'entrée `run_demarche_level_tasks()` regroupant les opérations de
  niveau démarche (instructeurs, labels, dossiers supprimés, masquage des colonnes
  `_id`), appelé sur les **deux** chemins de sortie. Chaque tâche est isolée dans
  son propre `try/except`.

Le rafraîchissement des labels n'est déclenché qu'en synchro incrémentale : en
sync complète, tous les dossiers sont refetchés et leurs labels réécrits par le
chemin principal.

## Changements de comportement

- Les instructeurs sont désormais synchronisés en fin de sync et non avant la
  boucle de lots. L'étape de progression « Instructeurs synchronisés » (25 %)
  disparaît.
- Le chemin de sortie anticipée exécute maintenant `IdColumnHider`, ce qu'il ne
  faisait pas — une colonne `_id` nouvellement créée restait visible tant
  qu'aucune sync ne remontait de dossier.
- Le rafraîchissement des labels ajoute `ceil(N/100)` requêtes DN séquentielles
  par sync incrémentale. Durée mesurable via la ligne `[TIMING]` des logs, ou en
  lançant `python labels_checker.py` en autonome.

## Test manuel

Sur une démarche déjà synchronisée, sans modifier aucun dossier :

- [x] ajouter un instructeur à un groupe → présent dans la table Instructeurs après la sync incrémentale suivante ;
- [x] poser une étiquette sur un dossier → `label_names` et `labels_json` à jour.
**testé sur Codespace**