### PR TITLE
Fix/suffixe stable doublons champs

### DIFF
--- a/grist_processor_working_all.py
+++ b/grist_processor_working_all.py
@@ -16,7 +16,8 @@ from dotenv import load_dotenv
 import repetable_processor as rp
 from deleted_dossiers_checker import check_deleted_dossiers
 from hide_id_columns import IdColumnHider
-from queries import dossier_to_flat_data, get_dossier
+from queries import get_dossier
+from queries_extract import dossier_to_flat_data
 from queries_graphql import get_demarche_dossiers_filtered
 from queries_util import get_timings
 from schema_utils import (

--- a/grist_processor_working_all.py
+++ b/grist_processor_working_all.py
@@ -12,8 +12,6 @@ from zoneinfo import ZoneInfo
 
 import requests
 from dotenv import load_dotenv
-from sync.tasks.instructeurs import sync_instructeurs
-from sync.tasks.labels import sync_labels_for_demarche
 
 import repetable_processor as rp
 from deleted_dossiers_checker import check_deleted_dossiers
@@ -27,6 +25,8 @@ from schema_utils import (
     get_demarche_schema_enhanced,
     update_grist_tables_from_schema,
 )
+from sync.tasks.instructeurs import sync_instructeurs
+from sync.tasks.labels import sync_labels_for_demarche
 from utils.api_validator import verify_api_connections
 from utils.constants import DEMARCHES_API_URL, EXIT_CODE_EXTERNAL_API_ERROR
 from utils.log_progress import LogProgress
@@ -2133,6 +2133,8 @@ def process_demarche_for_grist_optimized(
 
         log(f"Dossiers organisés en {batch_count} lots de {batch_size} maximum")
 
+        descriptor_to_column_id = column_types.get("descriptor_to_column_id", {})
+
         # Fonction pour préparer un seul dossier (DÉFINIE AVANT LA BOUCLE)
         def prepare_single_dossier(
             dossier_num, dossier_data, column_types, problematic_descriptor_ids
@@ -2144,6 +2146,7 @@ def process_demarche_for_grist_optimized(
                     dossier_data,
                     exclude_repetition_champs=exclude_repetition,
                     problematic_ids=problematic_descriptor_ids,
+                    descriptor_to_column_id=descriptor_to_column_id,
                 )
 
                 # Préparer dossier_record

--- a/queries_extract.py
+++ b/queries_extract.py
@@ -854,7 +854,10 @@ def extract_instructeurs_from_demarche(demarche_number: int) -> List[Dict[str, A
 
 
 def dossier_to_flat_data(
-    dossier_data: Dict[str, Any], exclude_repetition_champs=True, problematic_ids=None
+    dossier_data: Dict[str, Any],
+    exclude_repetition_champs=True,
+    problematic_ids=None,
+    descriptor_to_column_id=None,
 ) -> Dict[str, Any]:
     """
     Transforme les données d'un dossier en un format plat pour faciliter l'intégration.
@@ -957,16 +960,19 @@ def dossier_to_flat_data(
 
         # Appliquer les suffixes pour les doublons
         for item in extracted:
-            base_label = item["base_label"]
-            normalized = normalize_column_name(base_label)
-
-            # Gérer les doublons
-            if normalized in label_counters:
-                label_counters[normalized] += 1
-                item["label"] = f"{base_label}_{label_counters[normalized]}"
+            descriptor_id = item.get("descriptor_id")
+            if descriptor_to_column_id and descriptor_id in descriptor_to_column_id:
+                item["label"] = descriptor_to_column_id[descriptor_id]
             else:
-                label_counters[normalized] = 0
-                item["label"] = base_label
+                base_label = item["base_label"]
+                normalized = normalize_column_name(base_label)
+                if normalized not in label_counters:
+                    label_counters[normalized] = {}
+                descriptor_map = label_counters[normalized]
+                if descriptor_id not in descriptor_map:
+                    descriptor_map[descriptor_id] = len(descriptor_map)
+                suffix = descriptor_map[descriptor_id]
+                item["label"] = base_label if suffix == 0 else f"{base_label}_{suffix}"
 
         champ_values.extend(extracted)
 
@@ -991,31 +997,29 @@ def dossier_to_flat_data(
 
         # Appliquer les suffixes pour les doublons
         for item in extracted:
-            base_label = item["base_label"]
-            # Enlever le préfixe "annotation_" si présent pour la normalisation
-            label_for_normalization = base_label
-            if label_for_normalization.startswith("annotation_"):
-                label_for_normalization = label_for_normalization[11:]
-
-            normalized = normalize_column_name(label_for_normalization)
-
-            # Gérer les doublons
-            if normalized in annotation_label_counters:
-                annotation_label_counters[normalized] += 1
-                # Reconstruire le label avec annotation_ et le suffixe
-                if base_label.startswith("annotation_"):
-                    item["label"] = (
-                        f"{base_label}_{annotation_label_counters[normalized]}"
-                    )
-                else:
-                    item["label"] = (
-                        f"annotation_{base_label}_{annotation_label_counters[normalized]}"
-                    )
+            descriptor_id = item.get("descriptor_id")
+            if descriptor_to_column_id and descriptor_id in descriptor_to_column_id:
+                item["label"] = f"annotation_{descriptor_to_column_id[descriptor_id]}"
             else:
-                annotation_label_counters[normalized] = 0
-                # Garder le label tel quel (avec annotation_ si déjà présent)
-                if not base_label.startswith("annotation_"):
-                    item["label"] = f"annotation_{base_label}"
+                base_label = item["base_label"]
+                label_for_normalization = base_label
+                if label_for_normalization.startswith("annotation_"):
+                    label_for_normalization = label_for_normalization[11:]
+                normalized = normalize_column_name(label_for_normalization)
+                if normalized not in annotation_label_counters:
+                    annotation_label_counters[normalized] = {}
+                descriptor_map = annotation_label_counters[normalized]
+                if descriptor_id not in descriptor_map:
+                    descriptor_map[descriptor_id] = len(descriptor_map)
+                suffix = descriptor_map[descriptor_id]
+                base_with_prefix = (
+                    base_label
+                    if base_label.startswith("annotation_")
+                    else f"annotation_{base_label}"
+                )
+                item["label"] = (
+                    base_with_prefix if suffix == 0 else f"{base_with_prefix}_{suffix}"
+                )
 
         annotation_values.extend(extracted)
 

--- a/queries_extract.py
+++ b/queries_extract.py
@@ -961,7 +961,14 @@ def dossier_to_flat_data(
         # Appliquer les suffixes pour les doublons
         for item in extracted:
             descriptor_id = item.get("descriptor_id")
-            if descriptor_to_column_id and descriptor_id in descriptor_to_column_id:
+            # N'utiliser le mapping que si un seul item correspond à ce descriptor_id
+            # (les types multi-items comme CommuneChamp ont des base_label déjà distincts)
+            if (
+                descriptor_to_column_id
+                and descriptor_id in descriptor_to_column_id
+                and sum(1 for i in extracted if i.get("descriptor_id") == descriptor_id)
+                == 1
+            ):
                 item["label"] = descriptor_to_column_id[descriptor_id]
             else:
                 base_label = item["base_label"]

--- a/schema_utils.py
+++ b/schema_utils.py
@@ -530,8 +530,9 @@ def create_columns_from_schema(demarche_schema, demarche_number=None):
 
     # Variables pour suivre la présence de blocs répétables et champs carto
     has_repetable_blocks = False
-    repetable_blocks = {}  # NOUVEAU : Dict au lieu d'une seule liste
+    repetable_blocks = {}  # Dict au lieu d'une seule liste
     has_carto_fields = False
+    descriptor_to_column_id = {}  # {descriptor_id: colonne_id_suffixée stable}
 
     # Traiter les descripteurs de champs
     if demarche_schema.get("activeRevision") and demarche_schema["activeRevision"].get(
@@ -679,6 +680,7 @@ def create_columns_from_schema(demarche_schema, demarche_number=None):
                     counter += 1
 
                 # ✅ FORMAT AVEC FIELDS
+                descriptor_to_column_id[descriptor.get("id")] = normalized_label
                 champ_columns.append(
                     {
                         "id": normalized_label,
@@ -905,6 +907,7 @@ def create_columns_from_schema(demarche_schema, demarche_number=None):
                 counter += 1
 
             # ✅ FORMAT AVEC FIELDS
+            descriptor_to_column_id[descriptor.get("id")] = annotation_label
             annotation_columns.append(
                 {
                     "id": annotation_label,
@@ -919,6 +922,7 @@ def create_columns_from_schema(demarche_schema, demarche_number=None):
         "annotations": annotation_columns,
         "has_repetable_blocks": has_repetable_blocks,
         "has_carto_fields": has_carto_fields,
+        "descriptor_to_column_id": descriptor_to_column_id,
     }
 
     if has_repetable_blocks:

--- a/tests/python/unit/utils/test_queries_extract.py
+++ b/tests/python/unit/utils/test_queries_extract.py
@@ -1,0 +1,173 @@
+import os
+import sys
+
+sys.path.insert(
+    0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "..", "..")
+)
+
+from queries_extract import dossier_to_flat_data
+
+
+def make_champ(label, typename, descriptor_id, value=None, checked=None, selected=None):
+    """Fabrique un champ DS minimal."""
+    champ = {
+        "__typename": typename,
+        "id": f"id_{descriptor_id}",
+        "champDescriptorId": descriptor_id,
+        "label": label,
+        "updatedAt": "2024-01-01T00:00:00Z",
+        "prefilled": False,
+    }
+    if typename == "TextChamp":
+        champ["stringValue"] = value or ""
+    elif typename == "CheckboxChamp":
+        champ["checked"] = checked if checked is not None else False
+    elif typename == "YesNoChamp":
+        champ["selected"] = selected
+    return champ
+
+
+def make_dossier(champs, annotations=None):
+    """Fabrique un dossier DS minimal."""
+    return {
+        "id": "dossier_1",
+        "number": 1,
+        "state": "accepte",
+        "dateDepot": "2024-01-01T00:00:00Z",
+        "dateDerniereModification": "2024-01-01T00:00:00Z",
+        "dateDerniereModificationChamps": None,
+        "dateDerniereModificationAnnotations": None,
+        "datePassageEnConstruction": None,
+        "datePassageEnInstruction": None,
+        "dateExpiration": None,
+        "dateTraitement": None,
+        "dateSuppressionParUsager": None,
+        "dateAccuseLectureAgreement": None,
+        "labels": [],
+        "champs": champs,
+        "annotations": annotations or [],
+        "avis": [],
+        "usager": {"email": "test@test.fr"},
+        "demandeur": None,
+        "prenomMandataire": "",
+        "nomMandataire": "",
+        "deposeParUnTiers": False,
+    }
+
+
+class TestDossierToFlatDataDuplicateLabels:
+    """Tests sur la gestion des champs en doublon dans dossier_to_flat_data."""
+
+    def _get_labels(self, dossier, descriptor_to_column_id=None):
+        flat = dossier_to_flat_data(
+            dossier,
+            exclude_repetition_champs=True,
+            descriptor_to_column_id=descriptor_to_column_id,
+        )
+        return [item["label"] for item in flat["champs"]]
+
+    def test_no_duplicate_no_suffix(self):
+        """Un champ unique ne doit pas être suffixé."""
+        dossier = make_dossier(
+            [
+                make_champ("Nom", "TextChamp", "desc_001", value="Martin"),
+            ]
+        )
+        labels = self._get_labels(dossier)
+        assert "Nom" in labels
+        assert "Nom_1" not in labels
+
+    def test_two_duplicates_get_suffixes(self):
+        """Deux champs avec le même label → premier sans suffixe, second avec _1."""
+        dossier = make_dossier(
+            [
+                make_champ("Nom", "TextChamp", "desc_001", value="Martin"),
+                make_champ("Nom", "TextChamp", "desc_002", value="Dupont"),
+            ]
+        )
+        labels = self._get_labels(dossier)
+        assert "Nom" in labels
+        assert "Nom_1" in labels
+
+    def test_suffix_stable_regardless_of_order(self):
+        """
+        Avec le mapping du schéma DS, desc_001 → "Nom" et desc_002 → "Nom_1"
+        quel que soit l'ordre d'apparition dans les dossiers.
+        """
+        descriptor_to_column_id = {
+            "desc_001": "Nom",
+            "desc_002": "Nom_1",
+        }
+
+        dossier_a = make_dossier(
+            [
+                make_champ("Nom", "TextChamp", "desc_001", value="Martin"),
+                make_champ("Nom", "TextChamp", "desc_002", value="Dupont"),
+            ]
+        )
+        flat_a = dossier_to_flat_data(
+            dossier_a,
+            exclude_repetition_champs=True,
+            descriptor_to_column_id=descriptor_to_column_id,
+        )
+        labels_a = {item["label"]: item["value"] for item in flat_a["champs"]}
+
+        dossier_b = make_dossier(
+            [
+                make_champ("Nom", "TextChamp", "desc_002", value="Dupont"),
+                make_champ("Nom", "TextChamp", "desc_001", value="Martin"),
+            ]
+        )
+        flat_b = dossier_to_flat_data(
+            dossier_b,
+            exclude_repetition_champs=True,
+            descriptor_to_column_id=descriptor_to_column_id,
+        )
+        labels_b = {item["label"]: item["value"] for item in flat_b["champs"]}
+
+        assert labels_a.get("Nom") == "Martin"
+        assert labels_b.get("Nom") == "Martin"
+        assert labels_a.get("Nom_1") == "Dupont"
+        assert labels_b.get("Nom_1") == "Dupont"
+
+    def test_three_duplicates(self):
+        """Trois champs identiques → Nom, Nom_1, Nom_2."""
+        dossier = make_dossier(
+            [
+                make_champ("Nom", "TextChamp", "desc_001", value="A"),
+                make_champ("Nom", "TextChamp", "desc_002", value="B"),
+                make_champ("Nom", "TextChamp", "desc_003", value="C"),
+            ]
+        )
+        labels = self._get_labels(dossier)
+        assert "Nom" in labels
+        assert "Nom_1" in labels
+        assert "Nom_2" in labels
+
+    def test_different_labels_not_affected(self):
+        """Des champs avec des labels différents ne doivent pas être suffixés."""
+        dossier = make_dossier(
+            [
+                make_champ("Nom", "TextChamp", "desc_001", value="Martin"),
+                make_champ("Prénom", "TextChamp", "desc_002", value="Jean"),
+            ]
+        )
+        labels = self._get_labels(dossier)
+        assert "Nom" in labels
+        assert "Prénom" in labels
+        assert "Nom_1" not in labels
+        assert "Prénom_1" not in labels
+
+    def test_annotation_duplicates(self):
+        """Les annotations en doublon doivent aussi être gérées stablement."""
+        dossier = make_dossier(
+            champs=[],
+            annotations=[
+                make_champ("Avis", "TextChamp", "desc_010", value="OK"),
+                make_champ("Avis", "TextChamp", "desc_011", value="KO"),
+            ],
+        )
+        flat = dossier_to_flat_data(dossier, exclude_repetition_champs=True)
+        labels = [item["label"] for item in flat["annotations"]]
+        assert "annotation_Avis" in labels
+        assert "annotation_Avis_1" in labels

--- a/tests/python/unit/utils/test_queries_extract.py
+++ b/tests/python/unit/utils/test_queries_extract.py
@@ -1,11 +1,5 @@
-import os
-import sys
-
-sys.path.insert(
-    0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "..", "..")
-)
-
 from queries_extract import dossier_to_flat_data
+from schema_utils import create_columns_from_schema
 
 
 def make_champ(label, typename, descriptor_id, value=None, checked=None, selected=None):
@@ -53,6 +47,90 @@ def make_dossier(champs, annotations=None):
         "nomMandataire": "",
         "deposeParUnTiers": False,
     }
+
+
+def make_schema_with_duplicate_labels():
+    """Fabrique un schéma DS minimal avec deux champs de même label."""
+    return {
+        "title": "Test démarche",
+        "activeRevision": {
+            "champDescriptors": [
+                {
+                    "__typename": "TextChampDescriptor",
+                    "id": "desc_001",
+                    "type": "text",
+                    "label": "Nom",
+                    "description": "",
+                    "required": False,
+                },
+                {
+                    "__typename": "TextChampDescriptor",
+                    "id": "desc_002",
+                    "type": "text",
+                    "label": "Nom",
+                    "description": "",
+                    "required": False,
+                },
+            ],
+            "annotationDescriptors": [],
+        },
+    }
+
+
+class TestCreateColumnsFromSchemaDescriptorMapping:
+    """Tests sur la construction du mapping descriptor_to_column_id."""
+
+    def test_duplicate_labels_produce_distinct_column_ids(self):
+        """Deux descripteurs de même label → colonnes distinctes dans le mapping."""
+        schema = make_schema_with_duplicate_labels()
+        column_types, _ = create_columns_from_schema(schema)
+
+        mapping = column_types.get("descriptor_to_column_id", {})
+        assert "desc_001" in mapping
+        assert "desc_002" in mapping
+        assert mapping["desc_001"] != mapping["desc_002"]
+
+    def test_mapping_used_correctly_in_flat_data(self):
+        """Le mapping produit par create_columns_from_schema est utilisé stablement."""
+        schema = make_schema_with_duplicate_labels()
+        column_types, _ = create_columns_from_schema(schema)
+        descriptor_to_column_id = column_types["descriptor_to_column_id"]
+
+        # Dossier A : desc_001 en premier
+        dossier_a = make_dossier(
+            [
+                make_champ("Nom", "TextChamp", "desc_001", value="Martin"),
+                make_champ("Nom", "TextChamp", "desc_002", value="Dupont"),
+            ]
+        )
+        flat_a = dossier_to_flat_data(
+            dossier_a,
+            exclude_repetition_champs=True,
+            descriptor_to_column_id=descriptor_to_column_id,
+        )
+        labels_a = {item["label"]: item["value"] for item in flat_a["champs"]}
+
+        # Dossier B : desc_002 en premier
+        dossier_b = make_dossier(
+            [
+                make_champ("Nom", "TextChamp", "desc_002", value="Dupont"),
+                make_champ("Nom", "TextChamp", "desc_001", value="Martin"),
+            ]
+        )
+        flat_b = dossier_to_flat_data(
+            dossier_b,
+            exclude_repetition_champs=True,
+            descriptor_to_column_id=descriptor_to_column_id,
+        )
+        labels_b = {item["label"]: item["value"] for item in flat_b["champs"]}
+
+        col_001 = descriptor_to_column_id["desc_001"]
+        col_002 = descriptor_to_column_id["desc_002"]
+
+        assert labels_a.get(col_001) == "Martin"
+        assert labels_b.get(col_001) == "Martin"
+        assert labels_a.get(col_002) == "Dupont"
+        assert labels_b.get(col_002) == "Dupont"
 
 
 class TestDossierToFlatDataDuplicateLabels:
@@ -158,8 +236,8 @@ class TestDossierToFlatDataDuplicateLabels:
         assert "Nom_1" not in labels
         assert "Prénom_1" not in labels
 
-    def test_annotation_duplicates(self):
-        """Les annotations en doublon doivent aussi être gérées stablement."""
+    def test_annotation_duplicates_fallback(self):
+        """Les annotations en doublon sont gérées par le fallback (sans mapping schéma)."""
         dossier = make_dossier(
             champs=[],
             annotations=[
@@ -171,3 +249,25 @@ class TestDossierToFlatDataDuplicateLabels:
         labels = [item["label"] for item in flat["annotations"]]
         assert "annotation_Avis" in labels
         assert "annotation_Avis_1" in labels
+
+    def test_annotation_duplicates_with_mapping(self):
+        """Les annotations en doublon sont stables via le mapping schéma."""
+        descriptor_to_column_id = {
+            "desc_010": "Avis",
+            "desc_011": "Avis_1",
+        }
+        dossier = make_dossier(
+            champs=[],
+            annotations=[
+                make_champ("Avis", "TextChamp", "desc_011", value="KO"),
+                make_champ("Avis", "TextChamp", "desc_010", value="OK"),
+            ],
+        )
+        flat = dossier_to_flat_data(
+            dossier,
+            exclude_repetition_champs=True,
+            descriptor_to_column_id=descriptor_to_column_id,
+        )
+        labels = {item["label"]: item["value"] for item in flat["annotations"]}
+        assert labels.get("annotation_Avis") == "OK"
+        assert labels.get("annotation_Avis_1") == "KO"


### PR DESCRIPTION
basé sur le dernier main au 05/08/26

Correction du bug où deux champs conditionnels avec le même label 
produisaient des colonnes Grist instables selon l'ordre d'apparition 
dans les dossiers.

Le mapping {champDescriptorId → colonne_id} est désormais construit 
une seule fois depuis le schéma DS (create_columns_from_schema) et 
transmis à dossier_to_flat_data, garantissant que le même descripteur 
produit toujours le même identifiant de colonne quel que soit l'ordre 
d'apparition dans les dossiers.

Un fallback basé sur l'ordre d'apparition reste actif si le schéma 
n'est pas disponible.