### PR TITLE
Fix: plus de colonne vide pour les blocs répétables dans la table champs

### DIFF
--- a/schema_utils.py
+++ b/schema_utils.py
@@ -667,7 +667,11 @@ def create_columns_from_schema(demarche_schema, demarche_number=None):
 
             # Ajouter le champ normalisé à la table des champs
             # MAIS PAS pour les PieceJustificativeChamp car déjà traités ci-dessus
-            if descriptor.get("__typename") != "PieceJustificativeChampDescriptor":
+            # NI pour les RepetitionChamp (données stockées dans leur table dédiée)
+            if descriptor.get("__typename") not in [
+                "PieceJustificativeChampDescriptor",
+                "RepetitionChampDescriptor",
+            ]:
                 normalized_label = normalize_column_name(champ_label)
                 column_type = determine_column_type(
                     champ_type, descriptor.get("__typename")


### PR DESCRIPTION
La table `_champs` créait une colonne portant le nom du bloc répétable, jamais remplie puisque `dossier_to_flat_data` exclut les `RepetitionChamp` de cette table (les données vont dans `_repetable_<bloc>`).

Ajout de `RepetitionChampDescriptor` à l'exclusion existante (déjà appliquée à `PieceJustificativeChampDescriptor`) dans `create_columns_from_schema`.

⚠️ N'affecte que les nouvelles démarches / nouveaux blocs — les colonnes vides déjà créées dans les Grist docs existants ne sont pas supprimées rétroactivement.